### PR TITLE
Feature/adding-ignore-convention

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,35 +7,25 @@
             "type": "process",
             "args": [
                 "build",
-                "${workspaceFolder}/Samples/TypeDiscovery/TypeDiscovery.csproj",
+                "--no-restore",
                 "/property:GenerateFullPaths=true",
-                "/consoleloggerparameters:NoSummary"
+                "/consoleloggerparameters:NoSummary",
+                "${input:project}"
             ],
-            "problemMatcher": "$msCompile"
-        },
+            "problemMatcher": "$msCompile",
+            "runOptions": {
+                "reevaluateOnRerun": false
+            }
+        }
+    ],
+    "inputs": [
         {
-            "label": "publish",
-            "command": "dotnet",
-            "type": "process",
-            "args": [
-                "publish",
-                "${workspaceFolder}/Samples/TypeDiscovery/TypeDiscovery.csproj",
-                "/property:GenerateFullPaths=true",
-                "/consoleloggerparameters:NoSummary"
-            ],
-            "problemMatcher": "$msCompile"
-        },
-        {
-            "label": "watch",
-            "command": "dotnet",
-            "type": "process",
-            "args": [
-                "watch",
-                "run",
-                "--project",
-                "${workspaceFolder}/Samples/TypeDiscovery/TypeDiscovery.csproj"
-            ],
-            "problemMatcher": "$msCompile"
+            "id": "project",
+            "type": "command",
+            "command": "dotnet-build-commands.selectProject",
+            "args": {
+                "file": "${workspaceFolder}/.vscode/projects.json"
+            }
         }
     ]
 }

--- a/Source/DotNET/Fundamentals/DependencyInversion/IgnoreConventionAttribute.cs
+++ b/Source/DotNET/Fundamentals/DependencyInversion/IgnoreConventionAttribute.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.DependencyInjection;
+
+/// <summary>
+/// Attribute to adorn implementations that should be ignored by the IoC conventions.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class IgnoreConventionAttribute : Attribute;

--- a/Source/DotNET/Fundamentals/DependencyInversion/ServiceCollectionExtensions.cs
+++ b/Source/DotNET/Fundamentals/DependencyInversion/ServiceCollectionExtensions.cs
@@ -25,19 +25,25 @@ public static class ServiceCollectionExtensions
 
         static bool convention(Type i, Type t) => i.Namespace == t.Namespace && i.Name == $"I{t.Name}";
 
-        var conventionBasedTypes = types!.All.Where(_ =>
-        {
-            var interfaces = _.GetInterfaces();
-            if (interfaces.Length > 0)
+        var conventionBasedTypes = types!.All
+            .Where(_ =>
             {
-                var conventionInterface = interfaces.SingleOrDefault(i => convention(i, _));
-                if (conventionInterface != default)
+                if (_.HasAttribute<IgnoreConventionAttribute>())
                 {
-                    return types!.All.Count(type => type.HasInterface(conventionInterface)) == 1;
+                    return false;
                 }
-            }
-            return false;
-        });
+
+                var interfaces = _.GetInterfaces();
+                if (interfaces.Length > 0)
+                {
+                    var conventionInterface = interfaces.SingleOrDefault(i => convention(i, _));
+                    if (conventionInterface != default)
+                    {
+                        return types!.All.Count(type => type.HasInterface(conventionInterface)) == 1;
+                    }
+                }
+                return false;
+            });
 
         foreach (var conventionBasedType in conventionBasedTypes)
         {

--- a/Source/DotNET/Fundamentals/Timers/Timer.cs
+++ b/Source/DotNET/Fundamentals/Timers/Timer.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.DependencyInjection;
+
 namespace Cratis.Timers;
 
 /// <summary>
@@ -10,6 +12,7 @@ namespace Cratis.Timers;
 /// Initializes a new instance of the <see cref="Timer"/> class.
 /// </remarks>
 /// <param name="timer">The actual timer.</param>
+[IgnoreConvention]
 public class Timer(System.Threading.Timer timer) : ITimer
 {
     readonly System.Threading.Timer _timer = timer;


### PR DESCRIPTION
### Added

- Support for ignoring the automatic registrations by convention for the IoC. By using attribute `[IgnoreConvention]` on implementing types, it will be skipped for the conventions. It will only look for this on implementations and not interfaces.
