### PR TITLE
Adding model name system that can be used by any storage provider to resolve the name of a model

### DIFF
--- a/Source/DotNET/Fundamentals/Models/DefaultModelNameConvention.cs
+++ b/Source/DotNET/Fundamentals/Models/DefaultModelNameConvention.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Strings;
+using Humanizer;
+
+namespace Cratis.Models;
+
+/// <summary>
+/// Represents an implementation of <see cref="IModelNameConvention"/> for the default convention.
+/// </summary>
+/// <remarks>
+/// The default convention is to pluralize the type name and convert it to camel case.
+/// </remarks>
+public class DefaultModelNameConvention : IModelNameConvention
+{
+    /// <inheritdoc/>
+    public string GetNameFor(Type type)
+    {
+        var modelName = type.Name.Pluralize();
+        return modelName.ToCamelCase();
+    }
+}

--- a/Source/DotNET/Fundamentals/Models/IModelNameConvention.cs
+++ b/Source/DotNET/Fundamentals/Models/IModelNameConvention.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Models;
+
+/// <summary>
+/// Defines a convention for getting the name of a model.
+/// </summary>
+public interface IModelNameConvention
+{
+    /// <summary>
+    /// Get the name of the model.
+    /// </summary>
+    /// <param name="type"><see cref="Type"/> to get for.</param>
+    /// <returns>Name of the model.</returns>
+    string GetNameFor(Type type);
+}

--- a/Source/DotNET/Fundamentals/Models/IModelNameResolver.cs
+++ b/Source/DotNET/Fundamentals/Models/IModelNameResolver.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Models;
+
+/// <summary>
+/// Defines a resolver for getting the name of a read model.
+/// </summary>
+public interface IModelNameResolver
+{
+    /// <summary>
+    /// Get the name of the read model.
+    /// </summary>
+    /// <param name="readModelType">Type of read model to get for.</param>
+    /// <returns>Name of read model.</returns>
+    string GetNameFor(Type readModelType);
+}

--- a/Source/DotNET/Fundamentals/Models/ModelNameAttribute.cs
+++ b/Source/DotNET/Fundamentals/Models/ModelNameAttribute.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Models;
+
+/// <summary>
+/// Attribute that can be adorned a model type as metadata to indicate the actual name of the model.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="ModelNameAttribute"/> class.
+/// </remarks>
+/// <param name="name">Name of the model.</param>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+public sealed class ModelNameAttribute(string name) : Attribute
+{
+    /// <summary>
+    /// Gets the name of the model.
+    /// </summary>
+    public string Name { get; } = name;
+}

--- a/Source/DotNET/Fundamentals/Models/ModelNameResolver.cs
+++ b/Source/DotNET/Fundamentals/Models/ModelNameResolver.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using Cratis.Reflection;
+
+namespace Cratis.Models;
+
+/// <summary>
+/// Represents an implementation of <see cref="IModelNameConvention"/>.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="ModelNameResolver"/> class.
+/// </remarks>
+/// <param name="convention"><see cref="IModelNameConvention"/> to use.</param>
+public class ModelNameResolver(IModelNameConvention convention) : IModelNameResolver
+{
+    /// <inheritdoc/>
+    public string GetNameFor(Type readModelType)
+    {
+        if (readModelType.HasAttribute<ModelNameAttribute>())
+        {
+            return readModelType.GetCustomAttribute<ModelNameAttribute>(false)!.Name;
+        }
+
+        return convention.GetNameFor(readModelType);
+    }
+}

--- a/Source/DotNET/Fundamentals/Models/ModelsServiceCollectionExtensions.cs
+++ b/Source/DotNET/Fundamentals/Models/ModelsServiceCollectionExtensions.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Models;
+
+/// <summary>
+/// Extensions for <see cref="IServiceCollection"/> for adding model name conventions.
+/// </summary>
+public static class ModelsServiceCollectionExtensions
+{
+    /// <summary>
+    /// Add the default model name convention.
+    /// </summary>
+    /// <param name="services"><see cref="IServiceCollection"/> to add to.</param>
+    /// <returns><see cref="IServiceCollection"/> for continuing build.</returns>
+    public static IServiceCollection AddDefaultModelNameConvention(this IServiceCollection services) =>
+        services
+            .AddSingleton<IModelNameConvention, DefaultModelNameConvention>()
+            .AddSingleton<IModelNameResolver, ModelNameResolver>();
+
+    /// <summary>
+    /// Add a specific model name convention.
+    /// </summary>
+    /// <typeparam name="T">Type of <see cref="IModelNameConvention"/> to use.</typeparam>
+    /// <param name="services"><see cref="IServiceCollection"/> to add to.</param>
+    /// <returns><see cref="IServiceCollection"/> for continuing build.</returns>
+    public static IServiceCollection AddModelNameConvention<T>(this IServiceCollection services)
+        where T : class, IModelNameConvention =>
+        services
+            .AddSingleton<IModelNameConvention, T>()
+            .AddSingleton<IModelNameResolver, ModelNameResolver>();
+}

--- a/Source/DotNET/Fundamentals/Models/NamespacedModelNameConvention.cs
+++ b/Source/DotNET/Fundamentals/Models/NamespacedModelNameConvention.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Strings;
+using Humanizer;
+
+namespace Cratis.Models;
+
+/// <summary>
+/// Represents an implementation of <see cref="IModelNameConvention"/> that uses the namespace of the model type as a prefix.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="NamespacedModelNameConvention"/> class.
+/// </remarks>
+/// <param name="segmentsToSkip">Optionally number of segments in the namespace to skip. Defaults to 0.</param>
+/// <param name="separator">Optional separator character to use between namespace segments. Defaults to 0.</param>
+/// <param name="prefix">Optional prefix to prepend all collection names with.</param>
+public class NamespacedModelNameConvention(int segmentsToSkip = 0, char separator = '-', string prefix = "") : IModelNameConvention
+{
+    /// <inheritdoc/>
+    public string GetNameFor(Type type)
+    {
+        var segments = type.Namespace?.Split('.') ?? [];
+        var modelPrefix = string.Join(separator, segments.Skip(segmentsToSkip).Select(_ => _.ToCamelCase()));
+        return $"{prefix}{modelPrefix}-{type.Name.Pluralize().ToCamelCase()}";
+    }
+}


### PR DESCRIPTION
### Added

- Introduces a system for naming models, typically state that gets persisted in a data store like a database. This is a generic system which holds a convention based approach (pluralization) and supports prefixing with full CLR namespace if needed. It is also possible to specify the model name by using the `[ModelName]` attribute.
