### PR TITLE
Adding config method for setting up namespaced model convention

### DIFF
--- a/Source/DotNET/Fundamentals/Models/ModelsServiceCollectionExtensions.cs
+++ b/Source/DotNET/Fundamentals/Models/ModelsServiceCollectionExtensions.cs
@@ -25,8 +25,8 @@ public static class ModelsServiceCollectionExtensions
     /// </summary>
     /// <param name="services"><see cref="IServiceCollection"/> to add to.</param>
     /// <param name="segmentsToSkip">Optionally number of segments in the namespace to skip. Defaults to 0.</param>
-    /// <param name="separator">Optional separator character to use between namespace segments. Defaults to 0.</param>
-    /// <param name="prefix">Optional prefix to prepend all collection names with.</param>
+    /// <param name="separator">Optional separator character to use between namespace segments. Defaults to '-'.</param>
+    /// <param name="prefix">Optional prefix to prepend all model names with.</param>
     /// <returns><see cref="IServiceCollection"/> for continuing build.</returns>
     public static IServiceCollection AddNamespaceModelNameConvention(this IServiceCollection services, int segmentsToSkip = 0, char separator = '-', string prefix = "") =>
         services

--- a/Source/DotNET/Fundamentals/Models/ModelsServiceCollectionExtensions.cs
+++ b/Source/DotNET/Fundamentals/Models/ModelsServiceCollectionExtensions.cs
@@ -21,6 +21,19 @@ public static class ModelsServiceCollectionExtensions
             .AddSingleton<IModelNameResolver, ModelNameResolver>();
 
     /// <summary>
+    /// Add the namespaced model name convention.
+    /// </summary>
+    /// <param name="services"><see cref="IServiceCollection"/> to add to.</param>
+    /// <param name="segmentsToSkip">Optionally number of segments in the namespace to skip. Defaults to 0.</param>
+    /// <param name="separator">Optional separator character to use between namespace segments. Defaults to 0.</param>
+    /// <param name="prefix">Optional prefix to prepend all collection names with.</param>
+    /// <returns><see cref="IServiceCollection"/> for continuing build.</returns>
+    public static IServiceCollection AddNamespaceModelNameConvention(this IServiceCollection services, int segmentsToSkip = 0, char separator = '-', string prefix = "") =>
+        services
+            .AddSingleton<IModelNameConvention>(new NamespacedModelNameConvention(segmentsToSkip, separator, prefix))
+            .AddSingleton<IModelNameResolver, ModelNameResolver>();
+
+    /// <summary>
     /// Add a specific model name convention.
     /// </summary>
     /// <typeparam name="T">Type of <see cref="IModelNameConvention"/> to use.</typeparam>


### PR DESCRIPTION
### Fixed

- Exposing a method for configuring the namespaced model name convention:

```csharp
services.AddNamespaceModelNameConvention();
```

It takes optional parameters:

```csharp
services.AddNamespaceModelNameConvention(segmentsToSkip=1, separator='*', prefix="MyPrefix");
```

The `segmentsToSkip` tells the number of segments of the namespace skip. A segment is defined as what is separated with dots. So a `Fully.Qualified.Namespace` would be 3 segments. Default value is 0.

The `seperator` tells what to use as a separator between namespace segments. Default value is `-`.

The prefix can be used to specify a custom prefix in front.

The model name itself is resolved from the type as with the `DefaultModelNameConvention` which then camel case the name and pluralizes the result.

