### PR TITLE
Fixing namespace for extending service collectione

### DIFF
--- a/Source/DotNET/Fundamentals/Models/ModelsServiceCollectionExtensions.cs
+++ b/Source/DotNET/Fundamentals/Models/ModelsServiceCollectionExtensions.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Extensions.DependencyInjection;
+using Cratis.Models;
 
-namespace Cratis.Models;
+namespace Microsoft.Extensions.DependencyInjection;
 
 /// <summary>
 /// Extensions for <see cref="IServiceCollection"/> for adding model name conventions.


### PR DESCRIPTION
### Fixed

- The extensions for configuring the model name convention was in the wrong namespace, adding them to the `Microsoft.Extensions.DependencyInjection` namespace instead.
