### PR TITLE
Use the Guid.parse() for deserializing string representation of Guid

### DIFF
--- a/Source/JavaScript/JsonSerializer.ts
+++ b/Source/JavaScript/JsonSerializer.ts
@@ -14,7 +14,7 @@ const typeSerializers: Map<Constructor, typeSerializer> = new Map<Constructor, t
     [String, (value: any) => value],
     [Boolean, (value: any) => value],
     [Date, (value: any) => new Date(value)],
-    [Guid, (value: any) => new Guid(value)],
+    [Guid, (value: any) => Guid.parse(value.toString())],
 ]);
 
 const deserializeValue = (field: Field, value: any) => {


### PR DESCRIPTION
### Fixed

- JavaScript: JsonSerializer now uses the `Guid.parse()` method for deserializing the string representation of a `Guid` in JSON.
