### PR TITLE
Moving Metrics from ApplicationModel to Fundamentals

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,13 +3,14 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
 		<PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
 		<PackageVersion Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
 		<PackageVersion Include="System.Reactive" Version="6.0.0" />
 		<PackageVersion Include="Humanizer" Version="2.14.1" />
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-
+        <PackageVersion Include="handlebars.net" Version="2.1.4" />
+        <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.8.1" />
         <!-- Roslyn-->
         <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
         <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />

--- a/Fundamentals.sln
+++ b/Fundamentals.sln
@@ -9,6 +9,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fundamentals", "Source\DotN
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fundamentals", "Specifications\Fundamentals\Fundamentals.csproj", "{B6145456-0F67-4BF1-85B5-E03A7F67FE37}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "DotNET", "DotNET", "{74932E08-DDD9-47A6-879B-034F68D33F80}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Metrics.Roslyn", "Source\DotNET\Metrics.Roslyn\Metrics.Roslyn.csproj", "{CCB4390A-9DAC-4AE6-8381-AB4D5C5229E1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -26,8 +30,14 @@ Global
 		{B6145456-0F67-4BF1-85B5-E03A7F67FE37}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B6145456-0F67-4BF1-85B5-E03A7F67FE37}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B6145456-0F67-4BF1-85B5-E03A7F67FE37}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CCB4390A-9DAC-4AE6-8381-AB4D5C5229E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CCB4390A-9DAC-4AE6-8381-AB4D5C5229E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CCB4390A-9DAC-4AE6-8381-AB4D5C5229E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CCB4390A-9DAC-4AE6-8381-AB4D5C5229E1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{83E6AC5C-4F7C-4261-9898-DB72F3F9100A} = {B767D860-0EFF-4931-8F89-1F84145ECF56}
+		{74932E08-DDD9-47A6-879B-034F68D33F80} = {B767D860-0EFF-4931-8F89-1F84145ECF56}
+		{CCB4390A-9DAC-4AE6-8381-AB4D5C5229E1} = {74932E08-DDD9-47A6-879B-034F68D33F80}
 	EndGlobalSection
 EndGlobal

--- a/Source/DotNET/Fundamentals/Fundamentals.csproj
+++ b/Source/DotNET/Fundamentals/Fundamentals.csproj
@@ -10,5 +10,6 @@
       <PackageReference Include="System.IO.FileSystem.Primitives" />
       <PackageReference Include="System.Reactive" />
       <PackageReference Include="Humanizer" />
+      <PackageReference Include="OpenTelemetry.Exporter.InMemory" />
     </ItemGroup>
 </Project>

--- a/Source/DotNET/Fundamentals/Metrics/CounterAttribute.cs
+++ b/Source/DotNET/Fundamentals/Metrics/CounterAttribute.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Metrics;
+
+/// <summary>
+/// Attribute for marking a method as a counter for the metrics code generator.
+/// </summary>
+/// <typeparam name="T">Type of counter.</typeparam>
+/// <remarks>
+/// Initializes a new instance of <see cref="CounterAttribute{T}"/>.
+/// </remarks>
+/// <param name="name">Name of the counter.</param>
+/// <param name="description">Description of the counter.</param>
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class CounterAttribute<T>(string name, string description) : Attribute
+{
+    /// <summary>
+    /// Gets the name of the counter.
+    /// </summary>
+    public string Name { get; } = name;
+
+    /// <summary>
+    /// Gets the description of the counter.
+    /// </summary>
+    public string Description { get; } = description;
+}

--- a/Source/DotNET/Fundamentals/Metrics/IMeter.cs
+++ b/Source/DotNET/Fundamentals/Metrics/IMeter.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.Metrics;
+
+namespace Cratis.Metrics;
+
+/// <summary>
+/// Defines a meter for a specific type.
+/// </summary>
+/// <typeparam name="T">Type the meter is for.</typeparam>
+public interface IMeter<T>
+{
+    /// <summary>
+    /// Gets the actual <see cref="Meter"/> instance.
+    /// </summary>
+    Meter ActualMeter { get; }
+}

--- a/Source/DotNET/Fundamentals/Metrics/IMeterScope.cs
+++ b/Source/DotNET/Fundamentals/Metrics/IMeterScope.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.Metrics;
+
+namespace Cratis.Metrics;
+
+/// <summary>
+/// Defines a scope for metrics.
+/// </summary>
+/// <typeparam name="T">Type the scope is for.</typeparam>
+public interface IMeterScope<T> : IDisposable
+{
+    /// <summary>
+    /// Gets the <see cref="Meter"/> associated with the scope.
+    /// </summary>
+    Meter Meter { get; }
+
+    /// <summary>
+    /// Gets the tags associated with the scope.
+    /// </summary>
+    IDictionary<string, object> Tags { get; }
+}

--- a/Source/DotNET/Fundamentals/Metrics/MeasurementAttribute.cs
+++ b/Source/DotNET/Fundamentals/Metrics/MeasurementAttribute.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Metrics;
+
+/// <summary>
+/// Attribute for marking a method as a measurement for the metrics code generator.
+/// </summary>
+/// <typeparam name="T">Type of counter.</typeparam>
+/// <remarks>
+/// Initializes a new instance of <see cref="MeasurementAttribute{T}"/>.
+/// </remarks>
+/// <param name="name">Name of the counter.</param>
+/// <param name="description">Description of the counter.</param>
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class MeasurementAttribute<T>(string name, string description) : Attribute
+{
+    /// <summary>
+    /// Gets the name of the counter.
+    /// </summary>
+    public string Name { get; } = name;
+
+    /// <summary>
+    /// Gets the description of the counter.
+    /// </summary>
+    public string Description { get; } = description;
+}

--- a/Source/DotNET/Fundamentals/Metrics/Meter.cs
+++ b/Source/DotNET/Fundamentals/Metrics/Meter.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.Metrics;
+
+namespace Cratis.Metrics;
+
+/// <summary>
+/// Represents a typed <see cref="Meter"/>.
+/// </summary>
+/// <typeparam name="T">Type the meter is for.</typeparam>
+/// <remarks>
+/// Initializes a new instance of the <see cref="Meter{T}"/> class.
+/// </remarks>
+/// <param name="meter">The actual meter being used.</param>
+public class Meter<T>(Meter meter) : IMeter<T>
+{
+    /// <inheritdoc/>
+    public Meter ActualMeter { get; } = meter;
+}

--- a/Source/DotNET/Fundamentals/Metrics/MeterExtensions.cs
+++ b/Source/DotNET/Fundamentals/Metrics/MeterExtensions.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Metrics;
+
+/// <summary>
+/// Extension methods for working with meters.
+/// </summary>
+public static class MeterExtensions
+{
+    /// <summary>
+    /// Begin a scope for a meter.
+    /// </summary>
+    /// <param name="meter">The meter to begin scope for.</param>
+    /// <param name="tags">The tags associated with the scope.</param>
+    /// <typeparam name="T">Type the scope is for.</typeparam>
+    /// <returns>A new <see cref="IMeterScope{T}"/>.</returns>
+    public static IMeterScope<T> BeginScope<T>(this IMeter<T> meter, IDictionary<string, object> tags)
+    {
+        return new MeterScope<T>(meter, tags);
+    }
+}

--- a/Source/DotNET/Fundamentals/Metrics/MeterScope.cs
+++ b/Source/DotNET/Fundamentals/Metrics/MeterScope.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.Metrics;
+
+namespace Cratis.Metrics;
+
+/// <summary>
+/// Represents a scope for metrics.
+/// </summary>
+/// <typeparam name="T">Type the scope is for.</typeparam>
+/// <remarks>
+/// Initializes a new instance of the <see cref="MeterScope{T}"/> class.
+/// </remarks>
+/// <param name="meter">The <see cref="IMeter{T}"/> the scope is for.</param>
+/// <param name="tags">Tags associated with the scope.</param>
+public class MeterScope<T>(IMeter<T> meter, IDictionary<string, object> tags) : IMeterScope<T>
+{
+    /// <inheritdoc/>
+    public Meter Meter { get; } = meter.ActualMeter;
+
+    /// <inheritdoc/>
+    public IDictionary<string, object> Tags { get; } = tags;
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+    }
+}

--- a/Source/DotNET/Fundamentals/Metrics/MetricCollection.cs
+++ b/Source/DotNET/Fundamentals/Metrics/MetricCollection.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
+using OpenTelemetry.Metrics;
+
+namespace Cratis.Metrics;
+
+/// <summary>
+/// Represents a collection for <see cref="Metric"/>.
+/// </summary>
+public class MetricCollection : ICollection<MetricSnapshot>
+{
+    readonly IDictionary<string, MetricSnapshot> _metrics = new Dictionary<string, MetricSnapshot>();
+
+    readonly Dictionary<string, MetricMeasurement> _measurements = [];
+
+    /// <summary>
+    /// Content changed event.
+    /// </summary>
+    public event MetricCollectionContentChanged ContentChanged = () => { };
+
+    /// <summary>
+    /// Gets the collection og <see cref="MetricMeasurement"/>.
+    /// </summary>
+    public IEnumerable<MetricMeasurement> Measurements => _measurements.Values;
+
+    /// <inheritdoc/>
+    public int Count => _metrics.Count;
+
+    /// <inheritdoc/>
+    public bool IsReadOnly => false;
+
+    /// <inheritdoc/>
+    public void Add(MetricSnapshot item)
+    {
+        var sum = item.MetricPoints.Sum(point => item.MetricType switch
+        {
+            MetricType.LongSum => point.GetSumLong(),
+            MetricType.DoubleSum => point.GetSumDouble(),
+            MetricType.LongGauge => point.GetGaugeLastValueLong(),
+            MetricType.DoubleGauge => point.GetGaugeLastValueDouble(),
+            MetricType.Histogram => point.GetHistogramSum(),
+            _ => 0
+        });
+
+        var points = item.MetricPoints.Select(point =>
+        {
+            var value = item.MetricType switch
+            {
+                MetricType.LongSum => point.GetSumLong(),
+                MetricType.DoubleSum => point.GetSumDouble(),
+                MetricType.LongGauge => point.GetGaugeLastValueLong(),
+                MetricType.DoubleGauge => point.GetGaugeLastValueDouble(),
+                MetricType.Histogram => point.GetHistogramSum(),
+                _ => 0
+            };
+
+            var tags = new List<MetricMeasurementPointTag>();
+            foreach (var (tag, tagValue) in point.Tags)
+            {
+                tags.Add(new(tag, tagValue?.ToString() ?? string.Empty));
+            }
+
+            return new MetricMeasurementPoint(value, tags);
+        });
+
+        if (!_measurements.ContainsKey(item.Name) ||
+            _measurements[item.Name].Aggregated != sum ||
+            _measurements[item.Name].Points.Count() != points.Count())
+        {
+            _measurements[item.Name] = new MetricMeasurement(item.Name, sum, points);
+            ContentChanged();
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Clear() => _metrics.Clear();
+
+    /// <inheritdoc/>
+    public bool Contains(MetricSnapshot item) => _metrics.Values.Contains(item);
+
+    /// <inheritdoc/>
+    public void CopyTo(MetricSnapshot[] array, int arrayIndex) => _metrics.Values.CopyTo(array, arrayIndex);
+
+    /// <inheritdoc/>
+    public IEnumerator<MetricSnapshot> GetEnumerator() => _metrics.Values.GetEnumerator();
+
+    /// <inheritdoc/>
+    public bool Remove(MetricSnapshot item) => _metrics.Remove(item.Name);
+
+    /// <inheritdoc/>
+    IEnumerator IEnumerable.GetEnumerator() => _metrics.Values.GetEnumerator();
+}

--- a/Source/DotNET/Fundamentals/Metrics/MetricCollectionContentChanged.cs
+++ b/Source/DotNET/Fundamentals/Metrics/MetricCollectionContentChanged.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Metrics;
+
+/// <summary>
+/// Represents the delegate for content changed in a <see cref="MetricCollection"/>.
+/// </summary>
+public delegate void MetricCollectionContentChanged();

--- a/Source/DotNET/Fundamentals/Metrics/MetricMeasurement.cs
+++ b/Source/DotNET/Fundamentals/Metrics/MetricMeasurement.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Metrics;
+
+/// <summary>
+/// Represents a metric measurement.
+/// </summary>
+/// <param name="Name">Name of metric.</param>
+/// <param name="Aggregated">Aggregated value.</param>
+/// <param name="Points">Measurement points.</param>
+public record MetricMeasurement(string Name, double Aggregated, IEnumerable<MetricMeasurementPoint> Points);

--- a/Source/DotNET/Fundamentals/Metrics/MetricMeasurementPoint.cs
+++ b/Source/DotNET/Fundamentals/Metrics/MetricMeasurementPoint.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Metrics;
+
+/// <summary>
+/// Represents a metric measurement point.
+/// </summary>
+/// <param name="Value">Value of the point.</param>
+/// <param name="Tags">Tags for the points.</param>
+public record MetricMeasurementPoint(double Value, IEnumerable<MetricMeasurementPointTag> Tags);

--- a/Source/DotNET/Fundamentals/Metrics/MetricMeasurementPointTag.cs
+++ b/Source/DotNET/Fundamentals/Metrics/MetricMeasurementPointTag.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Metrics;
+
+/// <summary>
+/// Represents a metric measurement point tags.
+/// </summary>
+/// <param name="Tag">Name of tag.</param>
+/// <param name="Value">Value of the tag.</param>
+public record MetricMeasurementPointTag(string Tag, string Value);

--- a/Source/DotNET/Metrics.Roslyn/Metrics.Roslyn.csproj
+++ b/Source/DotNET/Metrics.Roslyn/Metrics.Roslyn.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <LangVersion>12.0</LangVersion>
+        <AssemblyName>Cratis.Metrics.Roslyn</AssemblyName>
+        <RootNamespace>Cratis.Metrics.Rolsyn</RootNamespace>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)/Templates/**/*.hbs" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="handlebars.net" GeneratePathProperty="true" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Update="@(PackageReference)" PrivateAssets="All" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Content Include="$(PKGHandlebars_Net)\lib\netstandard2.0\Handlebars.dll" PackagePath="analyzers/dotnet/cs" />
+        <Content Include="$(PKGHandlebars_Net)\lib\netstandard2.0\Handlebars.dll" PackagePath="lib/netstandard2.0" />
+    </ItemGroup>
+
+</Project>

--- a/Source/DotNET/Metrics.Roslyn/Metrics/MetricTemplateData.cs
+++ b/Source/DotNET/Metrics.Roslyn/Metrics/MetricTemplateData.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Metrics.Roslyn.Metrics;
+
+/// <summary>
+/// Represents the template for counters.
+/// </summary>
+public class MetricTemplateData
+{
+    /// <summary>
+    /// Gets or sets the type of counter.
+    /// </summary>
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the name of the counter method.
+    /// </summary>
+    public string MethodName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the signature of the method.
+    /// </summary>
+    public string MethodSignature { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the name of the counter.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the description of the counter.
+    /// </summary>
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets whether or the metric is scoped.
+    /// </summary>
+    public bool IsScoped { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the scope parameter.
+    /// </summary>
+    public string ScopeParameter { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the tags for the counter.
+    /// </summary>
+    public IEnumerable<TagTemplateData> Tags { get; set; } = [];
+}

--- a/Source/DotNET/Metrics.Roslyn/Metrics/MetricsSourceGenerator.cs
+++ b/Source/DotNET/Metrics.Roslyn/Metrics/MetricsSourceGenerator.cs
@@ -1,0 +1,161 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Cratis.Metrics.Roslyn.Templates;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Metrics.Roslyn.Metrics;
+
+/// <summary>
+/// Represents the source generator for metrics.
+/// </summary>
+[Generator]
+public class MetricsSourceGenerator : ISourceGenerator
+{
+    static readonly string[] _systemUsings =
+    [
+        "System.Diagnostics",
+        "System.Diagnostics.Metrics"
+    ];
+
+    /// <inheritdoc/>
+    public void Execute(GeneratorExecutionContext context)
+    {
+        if (context.SyntaxReceiver is not MetricsSyntaxReceiver receiver) return;
+
+        var counterAttribute = context.Compilation.GetTypeByMetadataName("Cratis.Metrics.CounterAttribute`1")!;
+        var measurementAttribute = context.Compilation.GetTypeByMetadataName("Cratis.Metrics.MeasurementAttribute`1")!;
+        foreach (var candidate in receiver.Candidates)
+        {
+            var classDefinition = $"{candidate.Modifiers} class {candidate.Identifier.ValueText}";
+            var usings = GetUsingsFor(candidate);
+
+            var templateData = new MetricsTemplateData
+            {
+                Namespace = (candidate.Parent as BaseNamespaceDeclarationSyntax)!.Name.ToString(),
+                ClassName = candidate.Identifier.ValueText,
+                ClassDefinition = classDefinition,
+                UsingStatements = usings.ToList()
+            };
+
+            var semanticModel = context.Compilation.GetSemanticModel(candidate.SyntaxTree);
+            foreach (var member in candidate.Members)
+            {
+                if (member is not MethodDeclarationSyntax method) continue;
+
+                var methodSymbol = semanticModel.GetDeclaredSymbol(method);
+                if (methodSymbol is not null)
+                {
+                    var attributes = methodSymbol.GetAttributes();
+                    var tags = GetParametersAsTags(method);
+                    var methodSignature = $"{method.Modifiers} {method.ReturnType} {method.Identifier.ValueText}({method.ParameterList.Parameters})";
+
+                    var isScoped = false;
+                    var scopeParameter = string.Empty;
+
+                    if (method.ParameterList.Parameters.Count > 0)
+                    {
+                        var type = method.ParameterList.Parameters[0].Type;
+                        if (type is GenericNameSyntax genericNameSyntax && genericNameSyntax.Identifier.ValueText == "IMeterScope")
+                        {
+                            isScoped = true;
+                            scopeParameter = method.ParameterList.Parameters[0].Identifier.ValueText;
+
+                            tags = tags.Skip(1);
+                        }
+                    }
+                    AddMetricIfAny(templateData.Counters, counterAttribute, method, methodSignature, attributes, isScoped, scopeParameter, tags);
+                    AddMetricIfAny(templateData.Measurements, measurementAttribute, method, methodSignature, attributes, isScoped, scopeParameter, tags);
+                }
+            }
+
+            if (templateData.Counters.Count > 0)
+            {
+                var source = TemplateTypes.Metrics(templateData);
+                context.AddSource($"{candidate.Identifier.ValueText}.g.cs", source);
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Initialize(GeneratorInitializationContext context)
+    {
+        context.RegisterForSyntaxNotifications(() => new MetricsSyntaxReceiver());
+    }
+
+    static IEnumerable<string> GetUsingsFor(ClassDeclarationSyntax candidate)
+    {
+        var current = candidate.Parent;
+
+        if (current is null)
+        {
+            return [];
+        }
+
+        var usings = new List<string>();
+
+        for (; ; )
+        {
+            usings.AddRange(current.DescendantNodes().OfType<UsingDirectiveSyntax>().Select(_ => _.Name?.ToString() ?? string.Empty));
+            if (current is CompilationUnitSyntax)
+            {
+                break;
+            }
+            current = current.Parent;
+            if (current is null)
+            {
+                break;
+            }
+        }
+
+        foreach (var usingNamespace in _systemUsings.Reverse())
+        {
+            if (!usings.Contains(usingNamespace))
+            {
+                usings.Insert(0, usingNamespace);
+            }
+        }
+
+        return usings.Distinct();
+    }
+
+    static IEnumerable<TagTemplateData> GetParametersAsTags(MethodDeclarationSyntax method) =>
+     method.ParameterList.Parameters.Select(parameter => new TagTemplateData
+     {
+         Name = parameter.Identifier.ValueText,
+         Type = parameter.Type!.ToString()
+     });
+
+    void AddMetricIfAny(
+        IList<MetricTemplateData> metrics,
+        INamedTypeSymbol attributeToLookFor,
+        MethodDeclarationSyntax method,
+        string methodSignature,
+        ImmutableArray<AttributeData> attributes,
+        bool isScoped,
+        string scopeParameter,
+        IEnumerable<TagTemplateData> tags)
+    {
+        var attribute = attributes.FirstOrDefault(_ => SymbolEqualityComparer.Default.Equals(_.AttributeClass?.OriginalDefinition, attributeToLookFor));
+        if (attribute is not null)
+        {
+            var type = attribute.AttributeClass!.TypeArguments[0].ToString();
+            var name = attribute.ConstructorArguments[0].Value!.ToString();
+            var description = attribute.ConstructorArguments[1].Value!.ToString();
+            metrics.Add(
+                    new MetricTemplateData
+                    {
+                        Name = name,
+                        Description = description,
+                        Type = type,
+                        MethodName = method.Identifier.ValueText,
+                        MethodSignature = methodSignature,
+                        IsScoped = isScoped,
+                        ScopeParameter = scopeParameter,
+                        Tags = tags
+                    });
+        }
+    }
+}

--- a/Source/DotNET/Metrics.Roslyn/Metrics/MetricsSyntaxReceiver.cs
+++ b/Source/DotNET/Metrics.Roslyn/Metrics/MetricsSyntaxReceiver.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Metrics.Roslyn.Metrics;
+
+/// <summary>
+/// Represents the syntax receiver for metrics.
+/// </summary>
+public class MetricsSyntaxReceiver : ISyntaxReceiver
+{
+    static readonly string[] _metricsAttributes =
+    [
+        "Counter",
+        "Measurement"
+    ];
+
+    readonly List<ClassDeclarationSyntax> _candidates = [];
+
+    /// <summary>
+    /// Gets the candidates for code generation.
+    /// </summary>
+    internal IEnumerable<ClassDeclarationSyntax> Candidates => _candidates;
+
+    /// <inheritdoc/>
+    public void OnVisitSyntaxNode(SyntaxNode syntaxNode)
+    {
+        if (syntaxNode is not ClassDeclarationSyntax classSyntax) return;
+
+        if (classSyntax.Modifiers.Any(modifier => modifier.IsKind(SyntaxKind.PartialKeyword)) &&
+            classSyntax.Modifiers.Any(modifier => modifier.IsKind(SyntaxKind.StaticKeyword)) &&
+            classSyntax.Members.Any(member => member.IsKind(SyntaxKind.MethodDeclaration) &&
+                HasMetricsAttribute(member) &&
+                member.Modifiers.Any(modifier => modifier.IsKind(SyntaxKind.PartialKeyword)) &&
+                member.Modifiers.Any(modifier => modifier.IsKind(SyntaxKind.StaticKeyword))))
+        {
+            _candidates.Add(classSyntax);
+        }
+    }
+
+    bool HasMetricsAttribute(MemberDeclarationSyntax memberSyntax) => memberSyntax
+                            .AttributeLists
+                            .SelectMany(_ => _.Attributes)
+                            .Any(_ => _metricsAttributes
+                                .Any(m => _.Name.ToString().StartsWith(m)));
+}

--- a/Source/DotNET/Metrics.Roslyn/Metrics/MetricsTemplateData.cs
+++ b/Source/DotNET/Metrics.Roslyn/Metrics/MetricsTemplateData.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Metrics.Roslyn.Metrics;
+
+/// <summary>
+/// REpresents the template the for metrics.
+/// </summary>
+public class MetricsTemplateData
+{
+    /// <summary>
+    /// Gets or sets the namespace.
+    /// </summary>
+    public string Namespace { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the class name.
+    /// </summary>
+    public string ClassName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the definition of the class.
+    /// </summary>
+    public string ClassDefinition { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the using statements.
+    /// </summary>
+    public IList<string> UsingStatements { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the counters.
+    /// </summary>
+    public IList<MetricTemplateData> Counters { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the measurements.
+    /// </summary>
+    public IList<MetricTemplateData> Measurements { get; set; } = [];
+}

--- a/Source/DotNET/Metrics.Roslyn/Metrics/TagTemplateData.cs
+++ b/Source/DotNET/Metrics.Roslyn/Metrics/TagTemplateData.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Metrics.Roslyn.Metrics;
+
+/// <summary>
+/// Represents the template for counter tags.
+/// </summary>
+public class TagTemplateData
+{
+    /// <summary>
+    /// Gets or sets the type of tag.
+    /// </summary>
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the name of the tag.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+}

--- a/Source/DotNET/Metrics.Roslyn/Templates/Metrics.hbs
+++ b/Source/DotNET/Metrics.Roslyn/Templates/Metrics.hbs
@@ -1,0 +1,43 @@
+{{#UsingStatements}}
+using {{this}};
+{{/UsingStatements}}
+
+namespace {{Namespace}};
+
+#nullable enable
+
+{{ClassDefinition}}
+{
+    {{#Counters}}
+    static Counter<{{Type}}>? {{MethodName}}Metric;
+    {{/Counters}}
+
+    {{#Counters}}
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Cratis.Roslyn.Extensions", "1.0.0")]
+    {{{MethodSignature}}}
+    {
+        {{#if IsScoped}}
+        if( {{MethodName}}Metric is null && {{ScopeParameter}}.Meter is not null )
+        {
+            {{MethodName}}Metric = {{ScopeParameter}}.Meter.CreateCounter<{{Type}}>("{{Name}}", "{{Description}}");
+        }
+        {{/if}}
+
+        var tags = new TagList(new ReadOnlySpan<KeyValuePair<string, object?>>(new KeyValuePair<string, object?>[]
+        {
+            {{#Tags}}
+            new("{{Name}}", {{name}}){{#unless @last}},{{/unless}}
+            {{/Tags}}
+        }));
+
+        {{#if IsScoped}}
+        foreach (var (key, value) in {{ScopeParameter}}.Tags)
+        {
+            tags.Add(key, value);
+        }
+        {{/if}}
+
+        {{MethodName}}Metric?.Add(1, tags);
+    }
+    {{/Counters}}
+}

--- a/Source/DotNET/Metrics.Roslyn/Templates/TemplateTypes.cs
+++ b/Source/DotNET/Metrics.Roslyn/Templates/TemplateTypes.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using HandlebarsDotNet;
+
+namespace Cratis.Metrics.Roslyn.Templates;
+
+/// <summary>
+/// Represents the template types.
+/// </summary>
+public static class TemplateTypes
+{
+    /// <summary>
+    /// Gets the metrics template.
+    /// </summary>
+    public static readonly HandlebarsTemplate<object, object> Metrics = Handlebars.Compile(GetTemplate("Metrics"));
+
+    static string GetTemplate(string name)
+    {
+        var rootType = typeof(TemplateTypes);
+        var stream = rootType.Assembly.GetManifestResourceStream($"{rootType.Namespace}.{name}.hbs");
+        if (stream != default)
+        {
+            using var reader = new StreamReader(stream);
+            return reader.ReadToEnd();
+        }
+
+        return string.Empty;
+    }
+}


### PR DESCRIPTION
### Added

- Metrics system moved from ApplicationModel. This means you don't need to have a dependency to ApplicationModel to use this.
