### PR TITLE
Fix/assembly-name

### DIFF
--- a/Source/DotNET/Metrics.Roslyn/MetricTemplateData.cs
+++ b/Source/DotNET/Metrics.Roslyn/MetricTemplateData.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Cratis.Metrics.Roslyn.Metrics;
+namespace Cratis.Metrics.Roslyn;
 
 /// <summary>
 /// Represents the template for counters.

--- a/Source/DotNET/Metrics.Roslyn/Metrics.Roslyn.csproj
+++ b/Source/DotNET/Metrics.Roslyn/Metrics.Roslyn.csproj
@@ -3,7 +3,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <LangVersion>12.0</LangVersion>
         <AssemblyName>Cratis.Metrics.Roslyn</AssemblyName>
-        <RootNamespace>Cratis.Metrics.Rolsyn</RootNamespace>
+        <RootNamespace>Cratis.Metrics.Roslyn</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>

--- a/Source/DotNET/Metrics.Roslyn/MetricsSourceGenerator.cs
+++ b/Source/DotNET/Metrics.Roslyn/MetricsSourceGenerator.cs
@@ -6,7 +6,7 @@ using Cratis.Metrics.Roslyn.Templates;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace Cratis.Metrics.Roslyn.Metrics;
+namespace Cratis.Metrics.Roslyn;
 
 /// <summary>
 /// Represents the source generator for metrics.

--- a/Source/DotNET/Metrics.Roslyn/MetricsSyntaxReceiver.cs
+++ b/Source/DotNET/Metrics.Roslyn/MetricsSyntaxReceiver.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace Cratis.Metrics.Roslyn.Metrics;
+namespace Cratis.Metrics.Roslyn;
 
 /// <summary>
 /// Represents the syntax receiver for metrics.

--- a/Source/DotNET/Metrics.Roslyn/MetricsTemplateData.cs
+++ b/Source/DotNET/Metrics.Roslyn/MetricsTemplateData.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Cratis.Metrics.Roslyn.Metrics;
+namespace Cratis.Metrics.Roslyn;
 
 /// <summary>
 /// REpresents the template the for metrics.

--- a/Source/DotNET/Metrics.Roslyn/TagTemplateData.cs
+++ b/Source/DotNET/Metrics.Roslyn/TagTemplateData.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Cratis.Metrics.Roslyn.Metrics;
+namespace Cratis.Metrics.Roslyn;
 
 /// <summary>
 /// Represents the template for counter tags.

--- a/Source/DotNET/Metrics.Roslyn/Templates/TemplateTypes.cs
+++ b/Source/DotNET/Metrics.Roslyn/Templates/TemplateTypes.cs
@@ -18,7 +18,8 @@ public static class TemplateTypes
     static string GetTemplate(string name)
     {
         var rootType = typeof(TemplateTypes);
-        var stream = rootType.Assembly.GetManifestResourceStream($"{rootType.Namespace}.{name}.hbs");
+        var resourceName = $"{rootType.Namespace}.{name}.hbs";
+        var stream = rootType.Assembly.GetManifestResourceStream(resourceName);
         if (stream != default)
         {
             using var reader = new StreamReader(stream);


### PR DESCRIPTION
### Fixed

- FIxing assembly name for the Roslyn extension. It didn't get the manifest resource stream since the namespace of the type used as "type safe" way to get resource name mismatched with the assemblyname.
