### PR TITLE
Fixing the assemblyProviders for AddTypeDiscovery()

### DIFF
--- a/Source/DotNET/Fundamentals/Types/TypesServiceCollectionExtensions.cs
+++ b/Source/DotNET/Fundamentals/Types/TypesServiceCollectionExtensions.cs
@@ -16,8 +16,14 @@ public static class TypesServiceCollectionExtensions
     /// <param name="services"><see cref="IServiceCollection"/> to add to.</param>
     /// <param name="assemblyProviders">Optional collection of <see cref="ICanProvideAssembliesForDiscovery"/>. Will default to <see cref="ProjectReferencedAssemblies"/> and <see cref="PackageReferencedAssemblies"/>.</param>
     /// <returns><see cref="IServiceCollection"/> for continuation.</returns>
-    public static IServiceCollection AddTypeDiscovery(this IServiceCollection services, IEnumerable<ICanProvideAssembliesForDiscovery>? assemblyProviders)
+    public static IServiceCollection AddTypeDiscovery(this IServiceCollection services, IEnumerable<ICanProvideAssembliesForDiscovery>? assemblyProviders = default)
     {
+        assemblyProviders ??=
+        [
+            ProjectReferencedAssemblies.Instance,
+            PackageReferencedAssemblies.Instance
+        ];
+
         var types = assemblyProviders is null ? new Types() : new Types(assemblyProviders);
         services.AddSingleton<ITypes>(types);
         services


### PR DESCRIPTION
### Fixed

- Fix the `AddTypeDiscovery()` service collection extension to do as its docs say; when no assembly discoverers are specified, use the default Project and Package assembly discoverers.
