### PR TITLE
Fixing the GeneratedCodeAttribute adorning metrics to point to correct location

### DIFF
--- a/Source/DotNET/Metrics.Roslyn/Templates/Metrics.hbs
+++ b/Source/DotNET/Metrics.Roslyn/Templates/Metrics.hbs
@@ -13,7 +13,7 @@ namespace {{Namespace}};
     {{/Counters}}
 
     {{#Counters}}
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Cratis.Roslyn.Extensions", "1.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Cratis.Metrics.Roslyn", "1.0.0")]
     {{{MethodSignature}}}
     {
         {{#if IsScoped}}


### PR DESCRIPTION
### Fixed

- Fixing the `GeneratedCodeAttribute` that gets added to metrics in the Roslyn extension to point to the correct namespace (Cratis.Metrics.Roslyn).
