### PR TITLE
Making sure we unwrap only generic tasks

### DIFF
--- a/Source/DotNET/Fundamentals/Reflection/MethodExtensions.cs
+++ b/Source/DotNET/Fundamentals/Reflection/MethodExtensions.cs
@@ -42,7 +42,7 @@ public static class MethodExtensions
     /// <returns>The actual type.</returns>
     public static Type GetActualReturnType(this MethodInfo methodInfo)
     {
-        if (methodInfo.IsAsync())
+        if (methodInfo.IsAsync() && methodInfo.ReturnType.IsGenericType)
         {
             return methodInfo.ReturnType.GetGenericArguments()[0];
         }


### PR DESCRIPTION
### Fixed

- Fixing unwrapping for actual types for `MethodInfo` extension to only do it for `Task<>`.
