### PR TITLE
Upgrading Microsoft.CodeAnalysis analyzers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,10 +12,10 @@
         <PackageVersion Include="handlebars.net" Version="2.1.4" />
         <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.8.1" />
         <!-- Roslyn-->
-        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
-        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.10.0" />
         <!-- Analysis -->
-        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.9.2" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.10.0" />
         <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" />
         <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" NoWarn="NU5104" />
         <PackageVersion Include="Roslynator.Analyzers" Version="4.12.2" />


### PR DESCRIPTION
### Fixed

- Upgrading to version 4.10.0 of Microsoft.CodeAnalysis.* packages.
