### PR TITLE
Make sure we don't fall over if we can't get the defined types from an assembly

### DIFF
--- a/Source/DotNET/Fundamentals/Types/PackageReferencedAssemblies.cs
+++ b/Source/DotNET/Fundamentals/Types/PackageReferencedAssemblies.cs
@@ -56,7 +56,17 @@ public class PackageReferencedAssemblies : ICanProvideAssembliesForDiscovery
                                 .Distinct()
                                 .ToArray();
             _assemblies.AddRange(assemblies);
-            DefinedTypes = _assemblies.SelectMany(_ => _.DefinedTypes).ToArray();
+            DefinedTypes = _assemblies.SelectMany(_ =>
+            {
+                try
+                {
+                    return _.DefinedTypes;
+                }
+                catch
+                {
+                    return [];
+                }
+            }).ToArray();
 
             _initialized = true;
         }


### PR DESCRIPTION
### Fixed

- Fixing so that we don't fall when getting DefinedTypes from an assembly if that assembly for some reason can't expose its defined types.
