### PR TITLE
Changing from .Single() to .First() - SoS case. Needs more analysis

### DIFF
--- a/Source/DotNET/Fundamentals/DependencyInversion/ServiceCollectionExtensions.cs
+++ b/Source/DotNET/Fundamentals/DependencyInversion/ServiceCollectionExtensions.cs
@@ -47,7 +47,7 @@ public static class ServiceCollectionExtensions
 
         foreach (var conventionBasedType in conventionBasedTypes)
         {
-            var interfaceToBind = types.All.Single(_ => _.IsInterface && convention(_, conventionBasedType));
+            var interfaceToBind = types.All.First(_ => _.IsInterface && convention(_, conventionBasedType));
             if (services.Any(_ => _.ServiceType == interfaceToBind) || conventionBasedType.IsAbstract)
             {
                 continue;


### PR DESCRIPTION
### Fixed

- For the convention hookup, I'm temporarily without any analysis doing a `.First()` for finding the interface to bind instead of `.Single()`. Having some issues with Chronicle and merged assemblies. Needs more analysis and will circle back to this.
