### PR TITLE
Fixing Json serializer to deserialize direct types without going through fields

### DIFF
--- a/Source/JavaScript/JsonSerializer.ts
+++ b/Source/JavaScript/JsonSerializer.ts
@@ -23,7 +23,7 @@ const deserializeValueFromType = (type: Constructor, value: any) => {
     } else {
         return JsonSerializer.deserialize(type, JSON.stringify(value));
     }
-}
+};
 
 const deserializeValueFromField = (field: Field, value: any) => {
     if (typeSerializers.has(field.type)) {

--- a/Source/JavaScript/for_JsonSerializer/when_deserializing_complex_nested_object_with_multiple_wellknown_types.ts
+++ b/Source/JavaScript/for_JsonSerializer/when_deserializing_complex_nested_object_with_multiple_wellknown_types.ts
@@ -4,7 +4,6 @@
 import { field } from '../fieldDecorator';
 import { JsonSerializer } from '../JsonSerializer';
 import { derivedType } from '../derivedTypeDecorator';
-import { Constructor } from '../Constructor';
 
 class OtherType {
     @field(Number)

--- a/Source/JavaScript/for_JsonSerializer/when_deserializing_guid.ts
+++ b/Source/JavaScript/for_JsonSerializer/when_deserializing_guid.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Guid } from '../Guid';
+import { JsonSerializer } from '../JsonSerializer';
+
+describe('when deserializing guid', () => {
+    const guidString = 'd2c7b1f3-5d5f-4d0a-8e3b-1b3f2c7e4d4d';
+    const json = `"${guidString}"`;
+    const result = JsonSerializer.deserialize(Guid, json);
+
+    it('should be a guid', () => result.should.be.instanceof(Guid));
+    it('should have the correct value', () => result.toString().should.equal(guidString));
+});

--- a/Source/JavaScript/for_JsonSerializer/when_deserializing_object_with_any_object_on_it.ts
+++ b/Source/JavaScript/for_JsonSerializer/when_deserializing_object_with_any_object_on_it.ts
@@ -1,9 +1,6 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-// Copyright (c) Cratis. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
 import { field } from '../fieldDecorator';
 import { JsonSerializer } from '../JsonSerializer';
 


### PR DESCRIPTION
### Fixed

- JavaScript `JsonSerializer` will deserialize known types directly if given directly. It assumed it was a complex object being passed to it and didn't really support known value types on top level.
