### PR TITLE
Adding a mechanism for current correlation id in the process

### DIFF
--- a/Source/DotNET/Fundamentals/Execution/CorrelationIdAccessor.cs
+++ b/Source/DotNET/Fundamentals/Execution/CorrelationIdAccessor.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.DependencyInjection;
+
+namespace Cratis.Execution;
+
+/// <summary>
+/// Represents an implementation of <see cref="ICorrelationIdAccessor"/>.
+/// </summary>
+[Singleton]
+public class CorrelationIdAccessor : ICorrelationIdAccessor
+{
+    static readonly AsyncLocal<CorrelationId> _current = new();
+
+    /// <inheritdoc/>
+    public CorrelationId Current => _current.Value ?? Guid.Empty;
+
+    /// <summary>
+    /// Internal: Set the current correlation ID.
+    /// </summary>
+    /// <param name="correlationId"><see cref="CorrelationId"/> to set.</param>
+    public static void SetCurrent(CorrelationId correlationId) => _current.Value = correlationId;
+}

--- a/Source/DotNET/Fundamentals/Execution/ICorrelationIdAccessor.cs
+++ b/Source/DotNET/Fundamentals/Execution/ICorrelationIdAccessor.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Execution;
+
+/// <summary>
+/// Defines a system that can access the current <see cref="CorrelationId"/>.
+/// </summary>
+public interface ICorrelationIdAccessor
+{
+    /// <summary>
+    /// Gets the current <see cref="CorrelationId"/>.
+    /// </summary>
+    CorrelationId Current { get; }
+}


### PR DESCRIPTION
### Added

- Adding `CorrelationIdAccessor` which offers an interface for accessing current `CorrelationId`. The implementation on top offers a static method of setting the current one, typically used by other infrastructural pieces at the correct entry points.

