### PR TITLE
Removing type requirement when serializing

### DIFF
--- a/Source/JavaScript/JsonSerializer.ts
+++ b/Source/JavaScript/JsonSerializer.ts
@@ -31,7 +31,7 @@ const serializeValueForType = (type: Constructor, value: any) => {
     if (typeConverters.has(type)) {
         return typeConverters.get(type)!(value);
     } else {
-        return convertTypesOnInstance(type, value);
+        return convertTypesOnInstance(value);
     }
 };
 
@@ -57,14 +57,14 @@ const deserializeValueFromField = (field: Field, value: any) => {
     }
 };
 
-const convertTypesOnInstance = (sourceType: Constructor, instance: any) => {
+const convertTypesOnInstance = (instance: any) => {
     const properties = Object.getOwnPropertyNames(instance);
     const converted: any = {};
     properties.forEach(property => {
         let value = instance[property];
         if (value !== undefined) {
             if (Array.isArray(value)) {
-                value = value.map(_ => convertTypesOnInstance(value.__proto__.constructor, _));
+                value = value.map(_ => convertTypesOnInstance(_));
             } else {
                 value = serializeValueForType(value.__proto__.constructor, value);
             }
@@ -84,12 +84,11 @@ export class JsonSerializer {
 
     /**
      * Serialize with strong type information.
-     * @param {Constructor} sourceType The type of the value to serialize.
      * @param {*} value The value to serialize.
      * @returns A JSON string.
      */
-    static serialize<TSource extends {}>(sourceType: Constructor<TSource>, value: TSource): string {
-        const converted = convertTypesOnInstance(sourceType, value);
+    static serialize(value: any): string {
+        const converted = convertTypesOnInstance(value);
         return JSON.stringify(converted);
     }
 

--- a/Source/JavaScript/for_JsonSerializer/when_serializing_complex_nested_object_with_multiple_wellknown_types.ts
+++ b/Source/JavaScript/for_JsonSerializer/when_serializing_complex_nested_object_with_multiple_wellknown_types.ts
@@ -30,7 +30,7 @@ describe('when serializing complex nested object with multiple wellknown types',
     instance.collectionOfOtherType[1].someGuid = Guid.parse('ee503799-63a7-4666-84b8-46eb1641206a');
     instance.collectionOfOtherType[1].someDate = new Date('2023-01-07 15:51');
    
-    const result = JsonSerializer.serialize(TopLevel, instance);
+    const result = JsonSerializer.serialize(instance);
     const deserialized = JSON.parse(result);
 
     it('should hold correct number for first level number', () => deserialized.someNumber.should.equal(42));


### PR DESCRIPTION
### Fixed

- Removing Type requirement on `.serialize()` on `JsonSerializer` for JavaScript. A mistake in version 5.6.0 released a few minutes ago.
