### PR TITLE
Removing eslint/compat + explicit import of globals

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,5 +43,6 @@
         <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All"/>
         <PackageReference Include="Roslynator.Analyzers" PrivateAssets="All"/>
         <PackageReference Include="Meziantou.Analyzer" PrivateAssets="All"/>
+        <PackageReference Include="System.Text.Json" />
     </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
         <PackageVersion Include="Humanizer" Version="2.14.1" />
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
         <PackageVersion Include="handlebars.net" Version="2.1.6" />
-        <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.10.0" />
+        
         <!-- Roslyn-->
         <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
         <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
@@ -23,17 +23,20 @@
         <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
         <PackageVersion Include="moq" Version="4.20.72" />
         <PackageVersion Include="Microsoft.NET.Test.SDK" Version="17.12.0" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-        <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
         <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="8.0.1" />
+        <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+        <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.9.0" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' OR '$(TargetFramework)' == 'netstandard2.0' ">
-        <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="9.0.0" />
+        <PackageVersion Include="System.Text.Json" Version="9.0.0" />
+        <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.10.0" />
     </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,13 +1,11 @@
 <Project>
-	<PropertyGroup>
-		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-	</PropertyGroup>
-	<ItemGroup>
-		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-		<PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="9.0.0" />
-		<PackageVersion Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
-		<PackageVersion Include="System.Reactive" Version="6.0.1" />
-		<PackageVersion Include="Humanizer" Version="2.14.1" />
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageVersion Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
+        <PackageVersion Include="System.Reactive" Version="6.0.1" />
+        <PackageVersion Include="Humanizer" Version="2.14.1" />
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
         <PackageVersion Include="handlebars.net" Version="2.1.6" />
         <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.10.0" />
@@ -16,7 +14,6 @@
         <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
         <!-- Analysis -->
         <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.11.0" />
-        <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" />
         <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" NoWarn="NU5104" />
         <PackageVersion Include="Roslynator.Analyzers" Version="4.12.9" />
         <PackageVersion Include="Meziantou.Analyzer" Version="2.0.182" />
@@ -26,5 +23,17 @@
         <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
         <PackageVersion Include="moq" Version="4.20.72" />
         <PackageVersion Include="Microsoft.NET.Test.SDK" Version="17.12.0" />
-	</ItemGroup>
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+        <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+        <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="8.0.1" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' OR '$(TargetFramework)' == 'netstandard2.0' ">
+        <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="9.0.0" />
+    </ItemGroup>
 </Project>


### PR DESCRIPTION
### Fixed

- Fixing depencies for .NET 8 TargetFramework - differentiating between .NET8 and .NET9 to avoid problems.
