### PR TITLE
Switching from .LoadFile() to .LoadFrom() to guarantee assembly binding context

### DIFF
--- a/Source/DotNET/Fundamentals/Types/AssemblyHelpers.cs
+++ b/Source/DotNET/Fundamentals/Types/AssemblyHelpers.cs
@@ -46,7 +46,7 @@ public static class AssemblyHelpers
             var path = Path.Join(AppDomain.CurrentDomain.BaseDirectory, file);
             if (File.Exists(path))
             {
-                return Assembly.LoadFile(path);
+                return Assembly.LoadFrom(path);
             }
 
             return null;


### PR DESCRIPTION
### Fixed

- Changing from `Assembly.LoadFrom()` to `Assembly.LoadFile()` to guarantee assemblies are loaded in the correct AppDomain context.