### PR TITLE
Now that extensions and open telemetry has .net 8 versions of their packages, we are simplifying

### DIFF
--- a/Directory.Packages.Net8.props
+++ b/Directory.Packages.Net8.props
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="[8.0.1]" />
-        <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="[8.0.2]" />
-        <PackageVersion Include="System.Text.Json" Version="[8.0.5]" />
-        <PackageVersion Include="OpenTelemetry" Version="[1.9.0]" />
-    </ItemGroup>
-</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,11 +25,7 @@
         <PackageVersion Include="moq" Version="4.20.72" />
         <PackageVersion Include="Microsoft.NET.Test.SDK" Version="17.13.0" />
         <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" />
-    </ItemGroup>
 
-    <Import Project="$(MSBuildThisFileDirectory)Directory.Packages.Net8.props" Condition=" '$(TargetFramework)' == 'net8.0' "/>
-
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' OR '$(TargetFramework)' == 'netstandard2.0' ">
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
         <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="9.0.3" />
         <PackageVersion Include="System.Text.Json" Version="9.0.3" />


### PR DESCRIPTION
### Fixed

- Removing specific dependencies for 3rd party packages for .NET 8 now that the packages we had separated out has support directly for .NET 8 as a target framework in their latest packages.
