### PR TITLE
Fix source code name

### DIFF
--- a/Source/DotNET/Metrics.Roslyn/MetricsSourceGenerator.cs
+++ b/Source/DotNET/Metrics.Roslyn/MetricsSourceGenerator.cs
@@ -25,8 +25,6 @@ public class MetricsSourceGenerator : ISourceGenerator
     {
         if (context.SyntaxReceiver is not MetricsSyntaxReceiver receiver) return;
 
-        while (!System.Diagnostics.Debugger.IsAttached) System.Threading.Thread.Sleep(10);
-
         var counterAttribute = context.Compilation.GetTypeByMetadataName("Cratis.Metrics.CounterAttribute`1")!;
         var gaugeAttribute = context.Compilation.GetTypeByMetadataName("Cratis.Metrics.GaugeAttribute`1")!;
         foreach (var candidate in receiver.Candidates)

--- a/Source/DotNET/Metrics.Roslyn/MetricsSourceGenerator.cs
+++ b/Source/DotNET/Metrics.Roslyn/MetricsSourceGenerator.cs
@@ -25,6 +25,8 @@ public class MetricsSourceGenerator : ISourceGenerator
     {
         if (context.SyntaxReceiver is not MetricsSyntaxReceiver receiver) return;
 
+        while (!System.Diagnostics.Debugger.IsAttached) System.Threading.Thread.Sleep(10);
+
         var counterAttribute = context.Compilation.GetTypeByMetadataName("Cratis.Metrics.CounterAttribute`1")!;
         var gaugeAttribute = context.Compilation.GetTypeByMetadataName("Cratis.Metrics.GaugeAttribute`1")!;
         foreach (var candidate in receiver.Candidates)

--- a/Source/DotNET/Metrics.Roslyn/MetricsSourceGenerator.cs
+++ b/Source/DotNET/Metrics.Roslyn/MetricsSourceGenerator.cs
@@ -74,7 +74,7 @@ public class MetricsSourceGenerator : ISourceGenerator
             if (templateData.Counters.Count > 0 && templateData.Gauge.Count > 0)
             {
                 var source = TemplateTypes.Metrics(templateData);
-                context.AddSource($"{candidate.Identifier.ValueText}.metrics.g.cs", source);
+                context.AddSource($"{candidate.Identifier.ValueText}.g.cs", source);
             }
         }
     }

--- a/Source/DotNET/Metrics.Roslyn/MetricsSourceGenerator.cs
+++ b/Source/DotNET/Metrics.Roslyn/MetricsSourceGenerator.cs
@@ -73,7 +73,8 @@ public class MetricsSourceGenerator : ISourceGenerator
                 }
             }
 
-            if (templateData.Counters.Count > 0 && templateData.Gauge.Count > 0)
+            if (templateData.Counters.Count > 0 ||
+                templateData.Gauge.Count > 0)
             {
                 var source = TemplateTypes.Metrics(templateData);
                 context.AddSource($"{candidate.Identifier.ValueText}.g.cs", source);


### PR DESCRIPTION
### Fixed

- Fixing source code name for the generated metrics.
- Make it generate code either when there are counters or gauges, not requiring both.
