### PR TITLE
Fixing correct method name for gauge recording

### DIFF
--- a/Source/DotNET/Metrics.Roslyn/Templates/Metrics.hbs
+++ b/Source/DotNET/Metrics.Roslyn/Templates/Metrics.hbs
@@ -34,13 +34,6 @@ namespace {{Namespace}};
             {{/Tags}}
         }));
 
-        {{#if IsScoped}}
-        foreach (var (key, value) in {{ScopeParameter}}.Tags)
-        {
-            tags.Add(key, value);
-        }
-        {{/if}}
-
         {{MethodName}}Metric?.Add(1, tags);
     }
     {{/Counters}}
@@ -63,14 +56,7 @@ namespace {{Namespace}};
             {{/Tags}}
         }));
 
-        {{#if IsScoped}}
-        foreach (var (key, value) in {{ScopeParameter}}.Tags)
-        {
-            tags.Add(key, value);
-        }
-        {{/if}}
-
-        {{MethodName}}Metric?.Add(1, tags);
+        {{MethodName}}Metric?.Record(1, tags);
     }
     {{/Gauges}}
 }


### PR DESCRIPTION
### Fixed

- Fixing the Gauge recording to call `.Record()` on the gauge.
