### PR TITLE
Adding scope tags back and getting the value parameter for Gauges

### DIFF
--- a/Source/DotNET/Metrics.Roslyn/MetricTemplateData.cs
+++ b/Source/DotNET/Metrics.Roslyn/MetricTemplateData.cs
@@ -49,6 +49,11 @@ public class MetricTemplateData
     public string ValueParameter { get; set; } = string.Empty;
 
     /// <summary>
+    /// Gets or sets whether or not the value parameter has a value.
+    /// </summary>
+    public bool HasValueParameter { get; set; }
+
+    /// <summary>
     /// Gets or sets the tags for the counter.
     /// </summary>
     public IEnumerable<TagTemplateData> Tags { get; set; } = [];

--- a/Source/DotNET/Metrics.Roslyn/MetricTemplateData.cs
+++ b/Source/DotNET/Metrics.Roslyn/MetricTemplateData.cs
@@ -44,6 +44,11 @@ public class MetricTemplateData
     public string ScopeParameter { get; set; } = string.Empty;
 
     /// <summary>
+    /// Gets or sets the value parameter.
+    /// </summary>
+    public string ValueParameter { get; set; } = string.Empty;
+
+    /// <summary>
     /// Gets or sets the tags for the counter.
     /// </summary>
     public IEnumerable<TagTemplateData> Tags { get; set; } = [];

--- a/Source/DotNET/Metrics.Roslyn/MetricsSourceGenerator.cs
+++ b/Source/DotNET/Metrics.Roslyn/MetricsSourceGenerator.cs
@@ -66,8 +66,9 @@ public class MetricsSourceGenerator : ISourceGenerator
                             tags = tags.Skip(1);
                         }
                     }
-                    AddMetricIfAny(templateData.Counters, counterAttribute, method, methodSignature, attributes, isScoped, scopeParameter, tags);
-                    AddMetricIfAny(templateData.Gauges, gaugeAttribute, method, methodSignature, attributes, isScoped, scopeParameter, tags);
+                    var valueParameter = method.ParameterList.Parameters[1].Identifier.ValueText;
+                    AddMetricIfAny(templateData.Counters, counterAttribute, method, methodSignature, attributes, isScoped, scopeParameter, valueParameter, tags);
+                    AddMetricIfAny(templateData.Gauges, gaugeAttribute, method, methodSignature, attributes, isScoped, scopeParameter, valueParameter, tags);
                 }
             }
 
@@ -137,6 +138,7 @@ public class MetricsSourceGenerator : ISourceGenerator
         ImmutableArray<AttributeData> attributes,
         bool isScoped,
         string scopeParameter,
+        string valueParameter,
         IEnumerable<TagTemplateData> tags)
     {
         var attribute = attributes.FirstOrDefault(_ => SymbolEqualityComparer.Default.Equals(_.AttributeClass?.OriginalDefinition, attributeToLookFor));
@@ -155,6 +157,7 @@ public class MetricsSourceGenerator : ISourceGenerator
                         MethodSignature = methodSignature,
                         IsScoped = isScoped,
                         ScopeParameter = scopeParameter,
+                        ValueParameter = valueParameter,
                         Tags = tags
                     });
         }

--- a/Source/DotNET/Metrics.Roslyn/MetricsSourceGenerator.cs
+++ b/Source/DotNET/Metrics.Roslyn/MetricsSourceGenerator.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;
+using System.Reflection;
 using Cratis.Metrics.Roslyn.Templates;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -20,6 +21,19 @@ public class MetricsSourceGenerator : ISourceGenerator
         "System.Diagnostics.Metrics"
     ];
 
+    static MetricsSourceGenerator()
+    {
+        AppDomain.CurrentDomain.AssemblyResolve += (sender, args) =>
+        {
+            if (args.Name.StartsWith("Handlebars"))
+            {
+                const string path = "/Volumes/Code/Cratis/Fundamentals/Source/DotNET/Metrics.Roslyn/bin/Debug/netstandard2.0/Handlebars.dll";
+                return File.Exists(path) ? Assembly.LoadFile(path) : null;
+            }
+            return null;
+        };
+    }
+
     /// <inheritdoc/>
     public void Execute(GeneratorExecutionContext context)
     {
@@ -27,6 +41,7 @@ public class MetricsSourceGenerator : ISourceGenerator
 
         var counterAttribute = context.Compilation.GetTypeByMetadataName("Cratis.Metrics.CounterAttribute`1")!;
         var gaugeAttribute = context.Compilation.GetTypeByMetadataName("Cratis.Metrics.GaugeAttribute`1")!;
+
         foreach (var candidate in receiver.Candidates)
         {
             var classDefinition = $"{candidate.Modifiers} class {candidate.Identifier.ValueText}";
@@ -49,26 +64,17 @@ public class MetricsSourceGenerator : ISourceGenerator
                 if (methodSymbol is not null)
                 {
                     var attributes = methodSymbol.GetAttributes();
-                    var tags = GetParametersAsTags(method);
                     var methodSignature = $"{method.Modifiers} {method.ReturnType} {method.Identifier.ValueText}({method.ParameterList.Parameters})";
 
-                    var isScoped = false;
-                    var scopeParameter = string.Empty;
+                    ValidateFirstParameter(context, method, methodSignature);
 
-                    if (method.ParameterList.Parameters.Count > 0)
-                    {
-                        var type = method.ParameterList.Parameters[0].Type;
-                        if (type is GenericNameSyntax genericNameSyntax && genericNameSyntax.Identifier.ValueText == "IMeterScope")
-                        {
-                            isScoped = true;
-                            scopeParameter = method.ParameterList.Parameters[0].Identifier.ValueText;
+                    var scopeParameter = method.ParameterList.Parameters[0].Identifier.ValueText;
 
-                            tags = tags.Skip(1);
-                        }
-                    }
-                    var valueParameter = method.ParameterList.Parameters[1].Identifier.ValueText;
-                    AddMetricIfAny(templateData.Counters, counterAttribute, method, methodSignature, attributes, isScoped, scopeParameter, valueParameter, tags);
-                    AddMetricIfAny(templateData.Gauges, gaugeAttribute, method, methodSignature, attributes, isScoped, scopeParameter, valueParameter, tags);
+                    var type = method.ParameterList.Parameters[0].Type;
+                    var isScoped = type?.ToString().StartsWith("IMeterScope") ?? false;
+
+                    AddMetricIfAny(context, templateData.Counters, counterAttribute, method, methodSignature, attributes, isScoped, scopeParameter);
+                    AddMetricIfAny(context, templateData.Gauges, gaugeAttribute, method, methodSignature, attributes, isScoped, scopeParameter, true);
                 }
             }
 
@@ -123,14 +129,70 @@ public class MetricsSourceGenerator : ISourceGenerator
         return usings.Distinct();
     }
 
-    static IEnumerable<TagTemplateData> GetParametersAsTags(MethodDeclarationSyntax method) =>
-     method.ParameterList.Parameters.Select(parameter => new TagTemplateData
-     {
-         Name = parameter.Identifier.ValueText,
-         Type = parameter.Type!.ToString()
-     });
+    static IEnumerable<ParameterSyntax> GetActualParameters(MethodDeclarationSyntax method) =>
+        method.ParameterList.Parameters.Skip(1);
+
+    static IEnumerable<TagTemplateData> GetParametersAsTags(IEnumerable<ParameterSyntax> parameters) =>
+        parameters.Select(parameter => new TagTemplateData
+        {
+            Name = parameter.Identifier.ValueText,
+            Type = parameter.Type!.ToString()
+        });
+
+    static void ValidateFirstParameter(GeneratorExecutionContext context, MethodDeclarationSyntax method, string methodSignature)
+    {
+        if (method.ParameterList.Parameters.Count == 0)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                new DiagnosticDescriptor(
+                    "METRICS001",
+                    "Missing required first parameter representing the type being extended",
+                    "Method '{0}' is missing a value parameter",
+                    "Metrics",
+                    DiagnosticSeverity.Error,
+                    true),
+                method.GetLocation(),
+                methodSignature));
+
+            return;
+        }
+
+        var parameterType = method.ParameterList.Parameters[0].Type?.ToString() ?? string.Empty;
+
+        if (!parameterType.StartsWith("IMeterScope") && !parameterType.StartsWith("IMeter"))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                new DiagnosticDescriptor(
+                    "METRICS002",
+                    "First parameter must be either an IMeter<> or IMeterScope<>",
+                    "Method '{0}' must either use IMeter<> or IMeterScope<> as the first parameter",
+                    "Metrics",
+                    DiagnosticSeverity.Error,
+                    true),
+                method.GetLocation(),
+                methodSignature));
+        }
+    }
+
+    static void ValidateValueParameter(GeneratorExecutionContext context, MethodDeclarationSyntax method, string methodSignature, string valueParameter, bool valueParameterRequired)
+    {
+        if (valueParameter.Length == 0 && valueParameterRequired)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                new DiagnosticDescriptor(
+                    "METRICS0013",
+                    "Missing required value parameter",
+                    "Method '{0}' is missing a value parameter",
+                    "Metrics",
+                    DiagnosticSeverity.Error,
+                    true),
+                method.GetLocation(),
+                methodSignature));
+        }
+    }
 
     void AddMetricIfAny(
+        GeneratorExecutionContext context,
         IList<MetricTemplateData> metrics,
         INamedTypeSymbol attributeToLookFor,
         MethodDeclarationSyntax method,
@@ -138,13 +200,22 @@ public class MetricsSourceGenerator : ISourceGenerator
         ImmutableArray<AttributeData> attributes,
         bool isScoped,
         string scopeParameter,
-        string valueParameter,
-        IEnumerable<TagTemplateData> tags)
+        bool valueParameterRequired = false)
     {
         var attribute = attributes.FirstOrDefault(_ => SymbolEqualityComparer.Default.Equals(_.AttributeClass?.OriginalDefinition, attributeToLookFor));
         if (attribute is not null)
         {
             var type = attribute.AttributeClass!.TypeArguments[0].ToString();
+
+            var parameters = GetActualParameters(method);
+            var valueParameter = parameters.FirstOrDefault(p => p.Type?.ToString() == type)?.Identifier.ValueText ?? string.Empty;
+            var hasValueParameter = valueParameter.Length > 0;
+            ValidateValueParameter(context, method, methodSignature, valueParameter, valueParameterRequired);
+            if (hasValueParameter)
+            {
+                parameters = parameters.Where(p => p.Identifier.ValueText != valueParameter);
+            }
+            var tags = GetParametersAsTags(parameters);
             var name = attribute.ConstructorArguments[0].Value!.ToString();
             var description = attribute.ConstructorArguments[1].Value!.ToString();
             metrics.Add(
@@ -158,6 +229,7 @@ public class MetricsSourceGenerator : ISourceGenerator
                         IsScoped = isScoped,
                         ScopeParameter = scopeParameter,
                         ValueParameter = valueParameter,
+                        HasValueParameter = hasValueParameter,
                         Tags = tags
                     });
         }

--- a/Source/DotNET/Metrics.Roslyn/Templates/Metrics.hbs
+++ b/Source/DotNET/Metrics.Roslyn/Templates/Metrics.hbs
@@ -34,6 +34,13 @@ namespace {{Namespace}};
             {{/Tags}}
         }));
 
+        {{#if IsScoped}}
+        foreach (var (key, value) in {{ScopeParameter}}.Tags)
+        {
+            tags.Add(key, value);
+        }
+        {{/if}}
+
         {{MethodName}}Metric?.Add(1, tags);
     }
     {{/Counters}}
@@ -56,7 +63,14 @@ namespace {{Namespace}};
             {{/Tags}}
         }));
 
-        {{MethodName}}Metric?.Record(1, tags);
+        {{#if IsScoped}}
+        foreach (var (key, value) in {{ScopeParameter}}.Tags)
+        {
+            tags.Add(key, value);
+        }
+        {{/if}}
+
+        {{MethodName}}Metric?.Record({{ValueParameter}}, tags);
     }
     {{/Gauges}}
 }

--- a/Source/DotNET/Metrics.Roslyn/Templates/Metrics.hbs
+++ b/Source/DotNET/Metrics.Roslyn/Templates/Metrics.hbs
@@ -25,6 +25,11 @@ namespace {{Namespace}};
         {
             {{MethodName}}Metric = {{ScopeParameter}}.Meter.CreateCounter<{{Type}}>("{{Name}}", "{{Description}}");
         }
+        {{else}}
+        if( {{MethodName}}Metric is null && {{ScopeParameter}}.ActualMeter is not null )
+        {
+            {{MethodName}}Metric = {{ScopeParameter}}.ActualMeter.CreateCounter<{{Type}}>("{{Name}}", "{{Description}}");
+        }
         {{/if}}
 
         var tags = new TagList(new ReadOnlySpan<KeyValuePair<string, object?>>(new KeyValuePair<string, object?>[]
@@ -41,7 +46,11 @@ namespace {{Namespace}};
         }
         {{/if}}
 
+        {{#if HasValueParameter }}
+        {{MethodName}}Metric?.Add({{ValueParameter}}, tags);
+        {{else}}
         {{MethodName}}Metric?.Add(1, tags);
+        {{/if}}
     }
     {{/Counters}}
 
@@ -52,7 +61,12 @@ namespace {{Namespace}};
         {{#if IsScoped}}
         if( {{MethodName}}Metric is null && {{ScopeParameter}}.Meter is not null )
         {
-            {{MethodName}}Metric = {{ScopeParameter}}.Meter.CreateGauge<{{Type}}>("{{Name}}", "{{Description}}");
+            {{MethodName}}Metric = {{ScopeParameter}}.Meter.CreateCounter<{{Type}}>("{{Name}}", "{{Description}}");
+        }
+        {{else}}
+        if( {{MethodName}}Metric is null && {{ScopeParameter}}.ActualMeter is not null )
+        {
+            {{MethodName}}Metric = {{ScopeParameter}}.ActualMeter.CreateCounter<{{Type}}>("{{Name}}", "{{Description}}");
         }
         {{/if}}
 


### PR DESCRIPTION
## Added

- Counter metrics honors a parameter with the same type as the value to add to the counter.
- Counter and Gauge metrics now fully support both an `IMeter<>` and `IMeterScope<>`.

### Fixed

- Misunderstanding during dev caused removal of scope tags for metrics.
- Using the actual value parameter (assuming first parameter after meter parameter) for Gauge recording.
- Compile time checks for invalid situations for the Metrics source generator.
- Fixed tag handling to include the parameters that are not the parameter value and combine it with scoped ones properly.