### PR TITLE
Don't lock down dependency versions

### DIFF
--- a/Source/JavaScript/package.json
+++ b/Source/JavaScript/package.json
@@ -36,6 +36,6 @@
         "up": "yarn g:up"
     },
     "dependencies": {
-        "reflect-metadata": "0.2.2"
+        "reflect-metadata": "^0.2.2"
     }
 }


### PR DESCRIPTION
### Fixed

- FIxing so that we don't lock down on dependency versions for 3rd parties, this is causing problems for consumers.
