### PR TITLE
Fix duplicate entry assembly in ProjectReferencedAssemblies

### DIFF
--- a/Source/DotNET/Fundamentals/Types/ProjectReferencedAssemblies.cs
+++ b/Source/DotNET/Fundamentals/Types/ProjectReferencedAssemblies.cs
@@ -52,7 +52,10 @@ public class ProjectReferencedAssemblies : ICanProvideAssembliesForDiscovery
                                 .Where(_ => _ is not null)
                                 .Distinct()
                                 .ToArray();
-            _assemblies.Add(entryAssembly);
+            if (!projectReferencedAssemblies.Contains(entryAssembly))
+            {
+                _assemblies.Add(entryAssembly);
+            }
             _assemblies.AddRange(projectReferencedAssemblies);
             DefinedTypes = [.. _assemblies.SelectMany(_ => _.DefinedTypes)];
 


### PR DESCRIPTION
## Fixes

- Only add the entry assembly to `_assemblies` if it is not already present in the project referenced assemblies list
