### PR TITLE
Add ComplexKeyDictionaryJsonConverterFactory and TypeScript ValueMap

### DIFF
--- a/Documentation/csharp/serialization/complex_key_dictionaries.md
+++ b/Documentation/csharp/serialization/complex_key_dictionaries.md
@@ -1,0 +1,39 @@
+# Complex Key Dictionaries
+
+The default JSON object model uses string property names. This means dictionaries with complex object keys need a custom conversion strategy to preserve typed keys across serialization boundaries.
+
+## Overview
+
+Fundamentals configures a `ComplexKeyDictionaryJsonConverterFactory` in global JSON options. The converter applies automatically to `IDictionary<TKey, TValue>` when `TKey` is a complex type.
+
+For each dictionary entry:
+
+1. The key object is serialized to compact JSON and used as the property name.
+2. The value is serialized using the configured `JsonSerializerOptions`.
+3. During deserialization, the key JSON string is deserialized back to the original key type.
+
+## Registration
+
+The converter is included in `Cratis.Json.Globals.Configure(...)` and therefore available anywhere Fundamentals JSON defaults are used.
+
+## Example
+
+```csharp
+public record AccountKey(Guid Id, string Tenant);
+public record AccountSummary(int Balance);
+
+var options = Cratis.Json.Globals.JsonSerializerOptions;
+
+IDictionary<AccountKey, AccountSummary> source =
+    new Dictionary<AccountKey, AccountSummary>
+    {
+        [new AccountKey(Guid.Parse("e094c582-9d91-4df0-b795-8d39fce089da"), "tenant-a")] = new AccountSummary(42)
+    };
+
+var json = JsonSerializer.Serialize(source, options);
+var roundTrip = JsonSerializer.Deserialize<IDictionary<AccountKey, AccountSummary>>(json, options);
+```
+
+## Frontend Interop
+
+For frontend usage and typed key lookup, see [ValueMap](../../typescript/serialization/value_map.md).

--- a/Documentation/csharp/serialization/index.md
+++ b/Documentation/csharp/serialization/index.md
@@ -5,4 +5,5 @@ This section covers various aspects of serialization in the Fundamentals package
 | Topic | Description |
 | ------- | ----------- |
 | [JSON Serialization](./serialization.md) | How to work with JSON serialization, polymorphism, and type discriminators. |
+| [Complex Key Dictionaries](./complex_key_dictionaries.md) | How to serialize and deserialize dictionaries with complex object keys. |
 | [Date & Time Only](./date_and_time_only.md) | How to work with DateOnly & TimeOnly for serializers and converters. |

--- a/Documentation/csharp/serialization/toc.yml
+++ b/Documentation/csharp/serialization/toc.yml
@@ -2,5 +2,7 @@
   href: serialization.md
 - name: Derived Types
   href: derived_types.md
+- name: Complex Key Dictionaries
+  href: complex_key_dictionaries.md
 - name: Date & Time Only
   href: date_and_time_only.md

--- a/Documentation/typescript/serialization/field_decorator.md
+++ b/Documentation/typescript/serialization/field_decorator.md
@@ -42,15 +42,17 @@ export class User {
 
 ### Decorator Parameters
 
-The `@field` decorator accepts three parameters:
+The `@field` decorator supports positional parameters and an options object.
 
 ```typescript
 @field(targetType: Constructor, enumerable?: boolean, derivatives?: Constructor[])
+@field(targetType: Constructor, { enumerable?: boolean, derivatives?: Constructor[], genericArguments?: Constructor[] })
 ```
 
 - **`targetType`**: The type constructor for the field (String, Number, Date, custom classes, etc.)
 - **`enumerable`**: Set to `true` for arrays/collections (default: `false`)
 - **`derivatives`**: Array of possible derived types for polymorphic fields (default: `[]`)
+- **`genericArguments`**: Generic type metadata for specialized types such as `ValueMap<TKey, TValue>`
 
 ## Field Types
 

--- a/Documentation/typescript/serialization/index.md
+++ b/Documentation/typescript/serialization/index.md
@@ -25,6 +25,7 @@ The serialization system consists of two main components that work together to p
 | [JsonSerializer](./json_serializer.md) | The core utility for type-safe JSON serialization and deserialization with runtime type preservation and method access. |
 | [Field Decorator](./field_decorator.md) | The `@field` decorator for runtime type information and proper object deserialization with full type safety. |
 | [DerivedTypes](./derived_types.md) | Polymorphic serialization system that works with backend .NET implementation for type-safe object resolution. |
+| [ValueMap](./value_map.md) | Map implementation for typed deserialization and value-based lookup of complex keys. |
 
 ## Quick Start
 

--- a/Documentation/typescript/serialization/toc.yml
+++ b/Documentation/typescript/serialization/toc.yml
@@ -6,3 +6,5 @@
   href: field_decorator.md
 - name: Derived Types
   href: derived_types.md
+- name: ValueMap
+  href: value_map.md

--- a/Documentation/typescript/serialization/value_map.md
+++ b/Documentation/typescript/serialization/value_map.md
@@ -1,0 +1,53 @@
+# ValueMap
+
+`ValueMap<TKey, TValue>` is a map implementation for complex keys where key equality is based on value content instead of object reference identity.
+
+## Why ValueMap
+
+When dictionaries with complex keys are serialized from the backend, key objects are represented as JSON property names. During frontend deserialization you often create new key instances for lookups, which do not match by reference.
+
+`ValueMap` solves this by comparing object keys by value.
+
+## Field Metadata and Generic Arguments
+
+To deserialize a `ValueMap` with typed keys and typed values, provide generic arguments through the `@field` decorator options:
+
+```typescript
+import { field, ValueMap } from '@cratis/fundamentals';
+
+class AccountKey {
+    @field(String)
+    tenant!: string;
+}
+
+class AccountSummary {
+    @field(Number)
+    balance!: number;
+}
+
+class Projection {
+    @field(ValueMap, { genericArguments: [AccountKey, AccountSummary] })
+    accounts!: ValueMap<AccountKey, AccountSummary>;
+}
+```
+
+## Behavior
+
+- Map keys are deserialized using the first generic argument.
+- Map values are deserialized using the second generic argument.
+- Lookup with a new key instance works when key content is equal.
+
+## Example
+
+```typescript
+const projection = JsonSerializer.deserialize(Projection, json);
+
+const key = new AccountKey();
+key.tenant = 'tenant-a';
+
+const summary = projection.accounts.get(key);
+```
+
+## Backend Interop
+
+For backend serialization details, see [Complex Key Dictionaries](../../csharp/serialization/complex_key_dictionaries.md).

--- a/Source/DotNET/Fundamentals.Specs/Json/for_ComplexKeyDictionaryJsonConverterFactory/when_serializing_and_deserializing_dictionary_with_complex_key.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_ComplexKeyDictionaryJsonConverterFactory/when_serializing_and_deserializing_dictionary_with_complex_key.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+
+namespace Cratis.Json.for_ComplexKeyDictionaryJsonConverterFactory;
+
+public class when_serializing_and_deserializing_dictionary_with_complex_key : Specification
+{
+    JsonSerializerOptions _options;
+    IDictionary<complex_key, complex_value> _dictionary;
+    string _json;
+    IDictionary<complex_key, complex_value> _deserialized;
+
+    void Establish()
+    {
+        _options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = true,
+            Converters = { new ComplexKeyDictionaryJsonConverterFactory() }
+        };
+
+        _dictionary = new Dictionary<complex_key, complex_value>
+        {
+            [new complex_key(Guid.Parse("e094c582-9d91-4df0-b795-8d39fce089da"), "tenant-a")] = new complex_value(42),
+            [new complex_key(Guid.Parse("486be95f-c860-4acd-b31e-39273b57bfc7"), "tenant-b")] = new complex_value(43)
+        };
+    }
+
+    void Because()
+    {
+        _json = JsonSerializer.Serialize(_dictionary, _options);
+        _deserialized = JsonSerializer.Deserialize<IDictionary<complex_key, complex_value>>(_json, _options)!;
+    }
+
+    [Fact] void should_serialize_key_as_compact_json() => _json.ShouldContain("\\u0022id\\u0022:\\u0022e094c582-9d91-4df0-b795-8d39fce089da\\u0022,\\u0022name\\u0022:\\u0022tenant-a\\u0022");
+    [Fact] void should_deserialize_two_items() => _deserialized.Count.ShouldEqual(2);
+    [Fact] void should_deserialize_first_key() => _deserialized.Keys.ShouldContain(new complex_key(Guid.Parse("e094c582-9d91-4df0-b795-8d39fce089da"), "tenant-a"));
+    [Fact] void should_deserialize_first_value() => _deserialized[new complex_key(Guid.Parse("e094c582-9d91-4df0-b795-8d39fce089da"), "tenant-a")].number.ShouldEqual(42);
+
+    public record complex_key(Guid id, string name);
+
+    public record complex_value(int number);
+}

--- a/Source/DotNET/Fundamentals/Json/ComplexKeyDictionaryJsonConverterFactory.cs
+++ b/Source/DotNET/Fundamentals/Json/ComplexKeyDictionaryJsonConverterFactory.cs
@@ -1,0 +1,134 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Cratis.Reflection;
+
+namespace Cratis.Json;
+
+/// <summary>
+/// Represents a <see cref="JsonConverterFactory"/> for dictionaries with complex key types.
+/// </summary>
+public class ComplexKeyDictionaryJsonConverterFactory : JsonConverterFactory
+{
+    /// <inheritdoc/>
+    public override bool CanConvert(Type typeToConvert)
+    {
+        if (!typeToConvert.IsDictionary())
+        {
+            return false;
+        }
+
+        var keyType = GetDictionaryKeyType(typeToConvert);
+        return IsComplexType(keyType);
+    }
+
+    /// <inheritdoc/>
+    public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+    {
+        var keyType = GetDictionaryKeyType(typeToConvert);
+        var valueType = GetDictionaryValueType(typeToConvert);
+        var converterType = typeof(ComplexKeyDictionaryJsonConverter<,,>).MakeGenericType(typeToConvert, keyType, valueType);
+        return (JsonConverter)Activator.CreateInstance(converterType)!;
+    }
+
+    static Type GetDictionaryKeyType(Type typeToConvert)
+    {
+        if (typeToConvert.IsGenericType && typeToConvert.GetGenericTypeDefinition() == typeof(IDictionary<,>))
+        {
+            return typeToConvert.GetGenericArguments()[0];
+        }
+
+        return typeToConvert.GetKeyType();
+    }
+
+    static Type GetDictionaryValueType(Type typeToConvert)
+    {
+        if (typeToConvert.IsGenericType && typeToConvert.GetGenericTypeDefinition() == typeof(IDictionary<,>))
+        {
+            return typeToConvert.GetGenericArguments()[1];
+        }
+
+        return typeToConvert.GetValueType();
+    }
+
+    static bool IsComplexType(Type type)
+    {
+        type = Nullable.GetUnderlyingType(type) ?? type;
+
+        return !type.IsPrimitive &&
+               !type.IsEnum &&
+               type != typeof(string) &&
+               type != typeof(Guid) &&
+               type != typeof(DateTime) &&
+               type != typeof(DateTimeOffset) &&
+               type != typeof(DateOnly) &&
+               type != typeof(TimeOnly) &&
+               type != typeof(TimeSpan) &&
+               type != typeof(decimal) &&
+               type != typeof(Uri);
+    }
+
+    sealed class ComplexKeyDictionaryJsonConverter<TDictionary, TKey, TValue> : JsonConverter<TDictionary>
+        where TKey : notnull
+    {
+        /// <inheritdoc/>
+        public override TDictionary Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var document = JsonDocument.ParseValue(ref reader);
+            var dictionary = CreateDictionary(typeToConvert);
+            var keySerializationOptions = GetKeySerializationOptions(options);
+
+            foreach (var property in document.RootElement.EnumerateObject())
+            {
+                var key = JsonSerializer.Deserialize<TKey>(property.Name, keySerializationOptions)!;
+                dictionary[key] = property.Value.Deserialize<TValue>(options)!;
+            }
+
+            return (TDictionary)(object)dictionary;
+        }
+
+        /// <inheritdoc/>
+        public override void Write(Utf8JsonWriter writer, TDictionary value, JsonSerializerOptions options)
+        {
+            if (value is null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            writer.WriteStartObject();
+            var keySerializationOptions = GetKeySerializationOptions(options);
+
+            foreach (var keyValue in (IDictionary<TKey, TValue>)(object)value)
+            {
+                var keyAsJson = JsonSerializer.Serialize(keyValue.Key, keySerializationOptions);
+                writer.WritePropertyName(keyAsJson);
+                JsonSerializer.Serialize(writer, keyValue.Value, options);
+            }
+
+            writer.WriteEndObject();
+        }
+
+        static IDictionary<TKey, TValue> CreateDictionary(Type typeToConvert)
+        {
+            if (typeToConvert.IsInterface || typeToConvert.IsAbstract)
+            {
+                return new Dictionary<TKey, TValue>();
+            }
+
+            if (Activator.CreateInstance(typeToConvert) is IDictionary<TKey, TValue> dictionary)
+            {
+                return dictionary;
+            }
+
+            return new Dictionary<TKey, TValue>();
+        }
+
+        static JsonSerializerOptions GetKeySerializationOptions(JsonSerializerOptions options) => new(options)
+        {
+            WriteIndented = false
+        };
+    }
+}

--- a/Source/DotNET/Fundamentals/Json/Globals.cs
+++ b/Source/DotNET/Fundamentals/Json/Globals.cs
@@ -47,6 +47,7 @@ public static class Globals
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
             Converters =
             {
+                new ComplexKeyDictionaryJsonConverterFactory(),
                 new EnumConverterFactory(),
                 new EnumerableConceptAsJsonConverterFactory(),
                 new ConceptAsJsonConverterFactory(),

--- a/Source/JavaScript/Field.ts
+++ b/Source/JavaScript/Field.ts
@@ -7,6 +7,11 @@ import { Constructor } from './Constructor';
  * Represents a field on a type.
  */
  export class Field {
-    constructor(readonly name: string, readonly type: Constructor, readonly enumerable: boolean, readonly derivatives: Constructor[]) {
+    constructor(
+        readonly name: string,
+        readonly type: Constructor,
+        readonly enumerable: boolean,
+        readonly derivatives: Constructor[],
+        readonly genericArguments: Constructor[]) {
     }
 }

--- a/Source/JavaScript/Fields.ts
+++ b/Source/JavaScript/Fields.ts
@@ -9,12 +9,12 @@ import { Field } from './Field';
  * Represents a system working with fields on types.
  */
 export class Fields {
-    static addFieldToType(target: Constructor, field: string, fieldType: Constructor, enumerable: boolean, derivatives: Constructor[]) {
+    static addFieldToType(target: Constructor, field: string, fieldType: Constructor, enumerable: boolean, derivatives: Constructor[], genericArguments: Constructor[]) {
         let fields: Map<string, Field> = new Map<string, Field>();
         if (Reflect.hasOwnMetadata('fields', target)) {
             fields = Reflect.getOwnMetadata('fields', target);
         }
-        fields.set(field, new Field(field, fieldType, enumerable, derivatives));
+        fields.set(field, new Field(field, fieldType, enumerable, derivatives, genericArguments));
         Reflect.defineMetadata('fields', fields, target);
     }
 

--- a/Source/JavaScript/JsonSerializer.ts
+++ b/Source/JavaScript/JsonSerializer.ts
@@ -7,6 +7,7 @@ import { Field } from './Field';
 import { Fields } from './Fields';
 import { Guid } from './Guid';
 import { TimeSpan } from './TimeSpan';
+import { ValueMap } from './ValueMap';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -18,7 +19,15 @@ const typeConverters: Map<Constructor, typeSerializer> = new Map<Constructor, ty
     [Boolean, (value: boolean) => value],
     [Date, (value: Date) => value.toISOString()],
     [Guid, (value: Guid) => value?.toString() ?? ''],
-    [TimeSpan, (value: TimeSpan) => value?.toString() ?? '']
+    [TimeSpan, (value: TimeSpan) => value?.toString() ?? ''],
+    [ValueMap, (value: ValueMap<any, any>) => {
+        const converted: any = {};
+        for (const [key, mapValue] of value.entries()) {
+            converted[serializeMapKey(key)] = convertTypesOnInstance(mapValue);
+        }
+
+        return converted;
+    }]
 ]);
 
 const typeSerializers: Map<Constructor, typeSerializer> = new Map<Constructor, typeSerializer>([
@@ -49,6 +58,10 @@ const deserializeValueFromType = (type: Constructor, value: any) => {
 };
 
 const deserializeValueFromField = (field: Field, value: any) => {
+    if (field.type === ValueMap) {
+        return deserializeValueMapFromField(field, value);
+    }
+
     if (typeSerializers.has(field.type)) {
         return typeSerializers.get(field.type)!(value);
     } else {
@@ -60,6 +73,80 @@ const deserializeValueFromField = (field: Field, value: any) => {
 
         return JsonSerializer.deserialize(type, JSON.stringify(value));
     }
+};
+
+const serializeMapKey = (key: any): string => {
+    if (key === undefined || key === null) {
+        return '';
+    }
+
+    if (typeof key === 'string') {
+        return key;
+    }
+
+    if (typeof key === 'number' || typeof key === 'boolean' || typeof key === 'bigint') {
+        return key.toString();
+    }
+
+    if (key instanceof Date) {
+        return key.toISOString();
+    }
+
+    return JsonSerializer.serialize(key);
+};
+
+const deserializeMapKey = (keyType: Constructor, key: string): any => {
+    if (keyType === String) {
+        return key;
+    }
+
+    if (keyType === Number) {
+        return Number(key);
+    }
+
+    if (keyType === Boolean) {
+        return key.toLowerCase() === 'true';
+    }
+
+    if (keyType === Date) {
+        return new Date(key);
+    }
+
+    if (typeSerializers.has(keyType)) {
+        return typeSerializers.get(keyType)!(key);
+    }
+
+    return JsonSerializer.deserialize(keyType, key);
+};
+
+const deserializeMapValue = (valueType: Constructor | undefined, value: any): any => {
+    if (!valueType) {
+        return value;
+    }
+
+    if (typeSerializers.has(valueType)) {
+        return typeSerializers.get(valueType)!(value);
+    }
+
+    return JsonSerializer.deserialize(valueType, JSON.stringify(value));
+};
+
+const deserializeValueMapFromField = (field: Field, value: any): ValueMap<any, any> => {
+    const valueMap = new ValueMap<any, any>();
+    const keyType = field.genericArguments[0];
+    const valueType = field.genericArguments[1];
+
+    if (!value || !keyType) {
+        return valueMap;
+    }
+
+    for (const key of Object.keys(value)) {
+        const deserializedKey = deserializeMapKey(keyType, key);
+        const deserializedValue = deserializeMapValue(valueType, value[key]);
+        valueMap.set(deserializedKey, deserializedValue);
+    }
+
+    return valueMap;
 };
 
 const convertTypesOnInstance = (instance: any) => {

--- a/Source/JavaScript/ValueMap.ts
+++ b/Source/JavaScript/ValueMap.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Represents a map that compares object keys by value.
+ */
+export class ValueMap<TKey, TValue> {
+    private readonly _entries: Array<[TKey, TValue]> = [];
+
+    set(key: TKey, value: TValue): this {
+        const index = this._entries.findIndex(([existingKey]) => this.equals(existingKey, key));
+        if (index >= 0) {
+            this._entries[index][1] = value;
+        } else {
+            this._entries.push([key, value]);
+        }
+
+        return this;
+    }
+
+    get(key: TKey): TValue | undefined {
+        return this._entries.find(([existingKey]) => this.equals(existingKey, key))?.[1];
+    }
+
+    entries(): IterableIterator<[TKey, TValue]> {
+        return this._entries.values();
+    }
+
+    private equals(first: TKey, second: TKey): boolean {
+        if (first === second) {
+            return true;
+        }
+
+        if (first === undefined || first === null || second === undefined || second === null) {
+            return false;
+        }
+
+        if (typeof first === 'object' && typeof second === 'object') {
+            return JSON.stringify(first) === JSON.stringify(second);
+        }
+
+        return false;
+    }
+}

--- a/Source/JavaScript/fieldDecorator.ts
+++ b/Source/JavaScript/fieldDecorator.ts
@@ -6,8 +6,22 @@ import { Fields } from './Fields';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-export function field(targetType: Constructor, enumerable?: boolean, derivatives?: Constructor[]) {
+type fieldOptions = {
+    enumerable?: boolean;
+    derivatives?: Constructor[];
+    genericArguments?: Constructor[];
+};
+
+const isFieldOptions = (value: boolean | fieldOptions | undefined): value is fieldOptions => {
+    return typeof value === 'object' && value !== null;
+};
+
+export function field(targetType: Constructor, enumerableOrOptions?: boolean | fieldOptions, derivatives?: Constructor[], genericArguments?: Constructor[]) {
+    const enumerable = isFieldOptions(enumerableOrOptions) ? (enumerableOrOptions.enumerable || false) : (enumerableOrOptions || false);
+    const actualDerivatives = isFieldOptions(enumerableOrOptions) ? (enumerableOrOptions.derivatives || []) : (derivatives || []);
+    const actualGenericArguments = isFieldOptions(enumerableOrOptions) ? (enumerableOrOptions.genericArguments || []) : (genericArguments || []);
+
     return function (target: any, propertyKey: string) {
-        Fields.addFieldToType(target.constructor, propertyKey, targetType, enumerable || false, derivatives || []);
+        Fields.addFieldToType(target.constructor, propertyKey, targetType, enumerable, actualDerivatives, actualGenericArguments);
     };
 }

--- a/Source/JavaScript/for_Fields/when_adding_fiields_to_type.ts
+++ b/Source/JavaScript/for_Fields/when_adding_fiields_to_type.ts
@@ -21,9 +21,9 @@ describe('when adding fields to type', () => {
     const secondFieldType = Number;
     const thirdFieldType = MyOtherType;
 
-    Fields.addFieldToType(MyType, firstField, firstFieldType, false, []);
-    Fields.addFieldToType(MyType, secondField, secondFieldType, false, [MyOtherType, MyThirdType]);
-    Fields.addFieldToType(MyType, thirdField, thirdFieldType, true, []);
+    Fields.addFieldToType(MyType, firstField, firstFieldType, false, [], []);
+    Fields.addFieldToType(MyType, secondField, secondFieldType, false, [MyOtherType, MyThirdType], [String, Number]);
+    Fields.addFieldToType(MyType, thirdField, thirdFieldType, true, [], []);
 
     const fields = Fields.getFieldsForType(MyType);
 
@@ -35,6 +35,7 @@ describe('when adding fields to type', () => {
     it('should have correct type for second field', () => fields[1].type.should.equal(secondFieldType));
     it('should not consider second field as enumerable', () => fields[1].enumerable.should.be.false);
     it('should have 2 derivatives for second field', () => fields[1].derivatives.length.should.equal(2));
+    it('should have 2 generic arguments for second field', () => fields[1].genericArguments.length.should.equal(2));
     it('should hold third field', () => fields[2].name.should.equal(thirdField));
     it('should have correct type for third field', () => fields[2].type.should.equal(thirdFieldType));
     it('should consider third field as enumerable', () => fields[2].enumerable.should.be.true);

--- a/Source/JavaScript/for_JsonSerializer/Types.ts
+++ b/Source/JavaScript/for_JsonSerializer/Types.ts
@@ -4,6 +4,7 @@
 import { field } from '../fieldDecorator';
 import { derivedType } from '../derivedTypeDecorator';
 import { Guid } from '../Guid';
+import { ValueMap } from '../ValueMap';
 
 export class OtherType {
     @field(Number)
@@ -41,6 +42,14 @@ export class SecondDerivative implements ITargetType {
     secondDerivativeProperty!: number;
 }
 
+export class MapKeyType {
+    @field(Guid)
+    keyId!: Guid;
+
+    @field(String)
+    keyName!: string;
+}
+
 export class TopLevel {
     @field(Number)
     someNumber!: number;
@@ -68,4 +77,7 @@ export class TopLevel {
 
     @field(Object, true, [FirstDerivative, SecondDerivative])
     collectionOfDerivedTypes!: ITargetType[];
+
+    @field(ValueMap, { genericArguments: [MapKeyType, OtherType] })
+    complexKeyMap!: ValueMap<MapKeyType, OtherType>;
 }

--- a/Source/JavaScript/for_JsonSerializer/when_deserializing_object_with_value_map.ts
+++ b/Source/JavaScript/for_JsonSerializer/when_deserializing_object_with_value_map.ts
@@ -1,0 +1,63 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Guid } from '../Guid';
+import { JsonSerializer } from '../JsonSerializer';
+import { MapKeyType, TopLevel } from './Types';
+
+const firstKey = {
+    keyId: 'e094c582-9d91-4df0-b795-8d39fce089da',
+    keyName: 'first'
+};
+
+const secondKey = {
+    keyId: '486be95f-c860-4acd-b31e-39273b57bfc7',
+    keyName: 'second'
+};
+
+const json = JSON.stringify({
+    complexKeyMap: {
+        [JSON.stringify(firstKey)]: {
+            someNumber: 42,
+            someString: 'forty two',
+            someDate: '2022-10-07T15:51:00.000Z',
+            someGuid: 'f0fa7c5e-9f7b-4688-8851-e0b6eeebe28b'
+        },
+        [JSON.stringify(secondKey)]: {
+            someNumber: 43,
+            someString: 'forty three',
+            someDate: '2022-11-07T15:51:00.000Z',
+            someGuid: 'a97f20cb-7f13-4f05-ab15-efb2b43c2457'
+        }
+    }
+});
+
+describe('when deserializing object with value map', () => {
+    const result = JsonSerializer.deserialize(TopLevel, json);
+
+    const expectedFirstKey = new MapKeyType();
+    expectedFirstKey.keyId = Guid.parse('e094c582-9d91-4df0-b795-8d39fce089da');
+    expectedFirstKey.keyName = 'first';
+
+    const expectedSecondKey = new MapKeyType();
+    expectedSecondKey.keyId = Guid.parse('486be95f-c860-4acd-b31e-39273b57bfc7');
+    expectedSecondKey.keyName = 'second';
+
+    const firstValue = result.complexKeyMap.get(expectedFirstKey)!;
+    const secondValue = result.complexKeyMap.get(expectedSecondKey)!;
+
+    it('should deserialize first key and value', () => {
+        firstValue.someNumber.should.equal(42);
+        firstValue.someGuid.toString().should.equal('f0fa7c5e-9f7b-4688-8851-e0b6eeebe28b');
+    });
+
+    it('should deserialize second key and value', () => {
+        secondValue.someNumber.should.equal(43);
+        secondValue.someGuid.toString().should.equal('a97f20cb-7f13-4f05-ab15-efb2b43c2457');
+    });
+
+    it('should deserialize map values as typed objects', () => {
+        firstValue.constructor.should.not.equal(Object);
+        secondValue.constructor.should.not.equal(Object);
+    });
+});

--- a/Source/JavaScript/for_JsonSerializer/when_serializing_object_with_value_map.ts
+++ b/Source/JavaScript/for_JsonSerializer/when_serializing_object_with_value_map.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Guid } from '../Guid';
+import { JsonSerializer } from '../JsonSerializer';
+import { ValueMap } from '../ValueMap';
+import { MapKeyType, OtherType, TopLevel } from './Types';
+
+describe('when serializing object with value map', () => {
+    const topLevel = new TopLevel();
+    topLevel.complexKeyMap = new ValueMap<MapKeyType, OtherType>();
+
+    const key = new MapKeyType();
+    key.keyId = Guid.parse('e094c582-9d91-4df0-b795-8d39fce089da');
+    key.keyName = 'first';
+
+    const value = new OtherType();
+    value.someNumber = 42;
+    value.someString = 'forty two';
+    value.someDate = new Date('2022-10-07T15:51:00.000Z');
+    value.someGuid = Guid.parse('f0fa7c5e-9f7b-4688-8851-e0b6eeebe28b');
+
+    topLevel.complexKeyMap.set(key, value);
+
+    const result = JsonSerializer.serialize(topLevel);
+    const parsed = JSON.parse(result);
+    const serializedKey = JSON.stringify({
+        keyId: 'e094c582-9d91-4df0-b795-8d39fce089da',
+        keyName: 'first'
+    });
+
+    it('should serialize key as compact json', () => parsed.complexKeyMap[serializedKey].should.not.be.undefined);
+    it('should serialize nested values', () => parsed.complexKeyMap[serializedKey].someNumber.should.equal(42));
+});

--- a/Source/JavaScript/index.ts
+++ b/Source/JavaScript/index.ts
@@ -10,6 +10,7 @@ export * from './PropertyAccessor';
 export * from './PropertyAccessorDescriptor';
 export * from './PropertyPathResolverProxyHandler';
 export * from './TimeSpan';
+export * from './ValueMap';
 export * from './fieldDecorator';
 export * from './derivedTypeDecorator';
 export * from './JsonSerializer';


### PR DESCRIPTION
## Added
- `ComplexKeyDictionaryJsonConverterFactory` for JSON serialization of `IDictionary<TKey,TValue>` where `TKey` is a complex type, encoding keys as JSON strings
- `ValueMap<K,V>` TypeScript type with complex-key equality support using JSON-stringify comparison
- `genericArguments` option on the `@field()` decorator for typed key/value deserialization of `ValueMap` fields
- Full serialization/deserialization support for `ValueMap` in `JsonSerializer`
