### PR TITLE
Fix DerivedTypeId to accept arbitrary strings instead of GUIDs

### DIFF
--- a/Documentation/csharp/serialization/derived_types.md
+++ b/Documentation/csharp/serialization/derived_types.md
@@ -92,9 +92,7 @@ When serialized, derived types include a special `_derivedTypeId` property:
 
 ## Uniqueness Requirements
 
-Derived type IDs must be **unique per interface** to enable proper polymorphic deserialization. While you can use any string format, using descriptive identifiers is recommended for readability:
-
-**Good approach** - Descriptive and unique:
+Derived type IDs must be **unique per interface** to enable proper polymorphic deserialization. The identifier is an arbitrary string — use whatever format makes sense for your domain:
 
 ```csharp
 [DerivedType("credit-card")]
@@ -104,17 +102,7 @@ public class CreditCard : IPaymentMethod { }
 public class PayPal : IPaymentMethod { }
 ```
 
-**Alternative approach** - Using GUIDs for maximum uniqueness:
-
-```csharp
-[DerivedType("550e8400-e29b-41d4-a716-446655440001")]
-public class CreditCard : IPaymentMethod { }
-
-[DerivedType("550e8400-e29b-41d4-a716-446655440002")]
-public class PayPal : IPaymentMethod { }
-```
-
-> **Note on GUIDs**: While GUIDs guarantee uniqueness, they sacrifice readability. If using GUIDs, ensure they are stored in shared constants to maintain consistency across your codebase and frontend services.
+Descriptive strings are strongly preferred — they make the serialized JSON readable and debugging straightforward.
 
 ## Advanced Scenarios
 
@@ -126,7 +114,7 @@ If a derived type implements multiple interfaces, you must specify which interfa
 public interface IPaymentMethod { }
 public interface IRefundable { }
 
-[DerivedType("550e8400-e29b-41d4-a716-446655440001", typeof(IPaymentMethod))]
+[DerivedType("credit-card", typeof(IPaymentMethod))]
 public class CreditCard : IPaymentMethod, IRefundable
 {
     // Implementation
@@ -141,7 +129,7 @@ The system automatically resolves target types based on implemented interfaces. 
 
 The system enforces several validation rules:
 
-1. **Unique Identifiers**: Each derived type must have a unique GUID identifier
+1. **Unique Identifiers**: Each derived type must have a unique string identifier
 2. **Single Target Type**: A derived type can only represent one target interface
 3. **Interface Implementation**: Derived types must implement their declared target interface
 

--- a/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypeJsonConverter/when_deserializing_for_known_derived_type.cs
+++ b/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypeJsonConverter/when_deserializing_for_known_derived_type.cs
@@ -8,7 +8,7 @@ namespace Cratis.Serialization.for_DerivedTypeJsonConverterFactory;
 
 public class when_deserializing_for_known_derived_type : Specification
 {
-    const string derived_type_id = "230fbbd7-6e87-43c8-a3e5-af69b8fd759d";
+    const string derived_type_id = "my-derived-type";
 
     const string json = $"{{\"{DerivedTypeJsonConverter<object>.DerivedTypeIdProperty}\":\"{derived_type_id}\", \"SomeValue\": 42 }}";
 

--- a/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypeJsonConverter/when_serializing_known_derived_type.cs
+++ b/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypeJsonConverter/when_serializing_known_derived_type.cs
@@ -8,7 +8,7 @@ namespace Cratis.Serialization.for_DerivedTypeJsonConverterFactory;
 
 public class when_serializing_known_derived_type : Specification
 {
-    const string derived_type_id = "230fbbd7-6e87-43c8-a3e5-af69b8fd759d";
+    const string derived_type_id = "my-derived-type";
     const string json = $"{{\"someValue\":42,\"{DerivedTypeJsonConverter<object>.DerivedTypeIdProperty}\":\"{derived_type_id}\"}}";
     interface ITargetType;
 

--- a/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_checking_if_has_derived_type_for_known_type.cs
+++ b/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_checking_if_has_derived_type_for_known_type.cs
@@ -7,7 +7,7 @@ public class when_checking_if_has_derived_type_for_known_type : given.derived_ty
 {
     interface ITargetType;
 
-    [DerivedType("fc13ac34-b69b-4438-8ebc-bc91bb5e2ee6")]
+    [DerivedType("known-type")]
     record DerivedType : ITargetType;
 
     bool result;

--- a/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_getting_derived_type_without_any_matching_derived_type_identifier.cs
+++ b/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_getting_derived_type_without_any_matching_derived_type_identifier.cs
@@ -7,7 +7,7 @@ public class when_getting_derived_type_without_any_matching_derived_type_identif
 {
     interface ITargetType;
 
-    [DerivedType("fc13ac34-b69b-4438-8ebc-bc91bb5e2ee6")]
+    [DerivedType("known-type")]
     record DerivedType : ITargetType { }
 
     DerivedTypes derived_types;
@@ -17,7 +17,7 @@ public class when_getting_derived_type_without_any_matching_derived_type_identif
 
     void Establish() => derived_types = new DerivedTypes(types.Object);
 
-    void Because() => result = Catch.Exception(() => _ = derived_types.GetDerivedTypeFor(typeof(ITargetType), "7ece19d8-2312-4335-a49e-3da5e88e2941"));
+    void Because() => result = Catch.Exception(() => _ = derived_types.GetDerivedTypeFor(typeof(ITargetType), "unknown-type"));
 
     [Fact] void should_throw_missing_derived_type_for_target_type() => result.ShouldBeOfExactType<MissingDerivedTypeForTargetType>();
 }

--- a/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_getting_derived_type_without_any_registration.cs
+++ b/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_getting_derived_type_without_any_registration.cs
@@ -10,7 +10,7 @@ public class when_getting_derived_type_without_any_registration : given.derived_
 
     void Establish() => derived_types = new DerivedTypes(types.Object);
 
-    void Because() => result = Catch.Exception(() => _ = derived_types.GetDerivedTypeFor(typeof(object), "7ece19d8-2312-4335-a49e-3da5e88e2941"));
+    void Because() => result = Catch.Exception(() => _ = derived_types.GetDerivedTypeFor(typeof(object), "unknown-type"));
 
     [Fact] void should_throw_missing_derived_type_for_target_type() => result.ShouldBeOfExactType<MissingDerivedTypeForTargetType>();
 }

--- a/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_getting_known_derived_type_that_matches.cs
+++ b/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_getting_known_derived_type_that_matches.cs
@@ -7,7 +7,7 @@ public class when_getting_known_derived_type_that_matches : given.derived_types
 {
     interface ITargetType;
 
-    [DerivedType("fc13ac34-b69b-4438-8ebc-bc91bb5e2ee6")]
+    [DerivedType("known-type")]
     record DerivedType : ITargetType { }
 
     DerivedTypes derived_types;
@@ -17,7 +17,7 @@ public class when_getting_known_derived_type_that_matches : given.derived_types
 
     void Establish() => derived_types = new DerivedTypes(types.Object);
 
-    void Because() => result = derived_types.GetDerivedTypeFor(typeof(ITargetType), "fc13ac34-b69b-4438-8ebc-bc91bb5e2ee6");
+    void Because() => result = derived_types.GetDerivedTypeFor(typeof(ITargetType), "known-type");
 
     [Fact] void should_return_derived_type() => result.ShouldEqual(typeof(DerivedType));
 }

--- a/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_getting_target_type_for_known_derived_type.cs
+++ b/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_getting_target_type_for_known_derived_type.cs
@@ -7,7 +7,7 @@ public class when_getting_target_type_for_known_derived_type : given.derived_typ
 {
     interface ITargetType;
 
-    [DerivedType("fc13ac34-b69b-4438-8ebc-bc91bb5e2ee6")]
+    [DerivedType("known-type")]
     record DerivedType : ITargetType { }
 
     DerivedTypes derived_types;

--- a/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_initializing_with_multiple_types_having_same_identifier.cs
+++ b/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_initializing_with_multiple_types_having_same_identifier.cs
@@ -7,10 +7,10 @@ public class when_initializing_with_multiple_types_having_same_identifier : give
 {
     interface ITargetType;
 
-    [DerivedType("fc13ac34-b69b-4438-8ebc-bc91bb5e2ee6")]
+    [DerivedType("first-type")]
     record FirstDerivedType : ITargetType { }
 
-    [DerivedType("fc13ac34-b69b-4438-8ebc-bc91bb5e2ee6")]
+    [DerivedType("first-type")]
     record SecondDerivedType : ITargetType { }
 
     Exception result;

--- a/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_initializing_with_type_with_multiple_target_types.cs
+++ b/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_initializing_with_type_with_multiple_target_types.cs
@@ -8,7 +8,7 @@ public class when_initializing_with_type_with_multiple_target_types : given.deri
     interface IFirst;
     interface ISecond;
 
-    [DerivedType("fc13ac34-b69b-4438-8ebc-bc91bb5e2ee6")]
+    [DerivedType("known-type")]
     record DerivedType : IFirst, ISecond { }
 
     Exception result;

--- a/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_initializing_with_type_with_target_type_but_no_target_types_implemented.cs
+++ b/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_initializing_with_type_with_target_type_but_no_target_types_implemented.cs
@@ -7,7 +7,7 @@ public class when_initializing_with_type_with_target_type_but_no_target_types_im
 {
     interface ITarget;
 
-    [DerivedType("fc13ac34-b69b-4438-8ebc-bc91bb5e2ee6", typeof(ITarget))]
+    [DerivedType("known-type", typeof(ITarget))]
     record DerivedType { }
 
     Exception result;

--- a/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_initializing_with_type_with_target_type_mismatch.cs
+++ b/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_initializing_with_type_with_target_type_mismatch.cs
@@ -8,7 +8,7 @@ public class when_initializing_with_type_with_target_type_mismatch : given.deriv
     interface IFirst;
     interface ISecond;
 
-    [DerivedType("fc13ac34-b69b-4438-8ebc-bc91bb5e2ee6", typeof(ISecond))]
+    [DerivedType("known-type", typeof(ISecond))]
     record DerivedType : IFirst { }
 
     Exception result;

--- a/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_initializing_without_target_type.cs
+++ b/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_initializing_without_target_type.cs
@@ -5,7 +5,7 @@ namespace Cratis.Serialization.for_DerivedTypes;
 
 public class when_initializing_without_target_type : given.derived_types
 {
-    [DerivedType("fc13ac34-b69b-4438-8ebc-bc91bb5e2ee6")]
+    [DerivedType("known-type")]
     record DerivedType { }
 
     Exception result;

--- a/Source/DotNET/Fundamentals/Serialization/DerivedTypeAttribute.cs
+++ b/Source/DotNET/Fundamentals/Serialization/DerivedTypeAttribute.cs
@@ -8,7 +8,7 @@ namespace Cratis.Serialization;
 /// <remarks>
 /// Initializes a new instance of the <see cref="DerivedTypeAttribute"/> class.
 /// </remarks>
-/// <param name="identifier">String representation of a <see cref="Guid"/>.</param>
+/// <param name="identifier">Arbitrary string that uniquely identifies the derived type.</param>
 /// <param name="targetType">Optional target type the derived type is for.</param>
 [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
 public sealed class DerivedTypeAttribute(string identifier, Type? targetType = default) : Attribute

--- a/Source/DotNET/Fundamentals/Serialization/DerivedTypeId.cs
+++ b/Source/DotNET/Fundamentals/Serialization/DerivedTypeId.cs
@@ -8,18 +8,18 @@ namespace Cratis.Serialization;
 /// <summary>
 /// The unique identifier identifying a derived type.
 /// </summary>
-/// <param name="id">The string representation of a <see cref="Guid"/> that identifies the type uniquely.</param>
-public record DerivedTypeId(Guid id) : ConceptAs<Guid>(id)
+/// <param name="id">The arbitrary string that identifies the type uniquely.</param>
+public record DerivedTypeId(string id) : ConceptAs<string>(id)
 {
     /// <summary>
-    /// Implicitly convert from <see cref="Guid"/> to <see cref="DerivedTypeId"/>.
+    /// Implicitly convert from a string to <see cref="DerivedTypeId"/>.
     /// </summary>
-    /// <param name="id"><see cref="Guid"/> to convert from.</param>
-    public static implicit operator DerivedTypeId(Guid id) => new(id);
+    /// <param name="id">String to convert from.</param>
+    public static implicit operator DerivedTypeId(string id) => new(id);
 
     /// <summary>
-    /// Implicitly convert from a string representation of a <see cref="Guid"/> to <see cref="DerivedTypeId"/>.
+    /// Implicitly convert from <see cref="DerivedTypeId"/> to string.
     /// </summary>
-    /// <param name="id">String <see cref="Guid"/> to convert from.</param>
-    public static implicit operator DerivedTypeId(string id) => new(Guid.Parse(id));
+    /// <param name="id"><see cref="DerivedTypeId"/> to convert from.</param>
+    public static implicit operator string(DerivedTypeId id) => id.Value;
 }

--- a/Source/DotNET/Fundamentals/Serialization/DerivedTypeJsonConverter.cs
+++ b/Source/DotNET/Fundamentals/Serialization/DerivedTypeJsonConverter.cs
@@ -33,7 +33,7 @@ public class DerivedTypeJsonConverter<T>(IDerivedTypes derivedTypes) : JsonConve
 
         if (document.RootElement.TryGetProperty(DerivedTypeIdProperty, out var value))
         {
-            var derivedTypeId = (DerivedTypeId)value.GetGuid();
+            var derivedTypeId = (DerivedTypeId)value.GetString()!;
             var derivedType = _derivedTypes.GetDerivedTypeFor(typeToConvert, derivedTypeId);
             var instance = document.Deserialize(derivedType, options);
             return (T)instance!;


### PR DESCRIPTION
## Fixed
- `DerivedTypeId` now accepts any arbitrary string instead of requiring a GUID format, preventing a `FormatException` at startup when `[DerivedType]` attributes use descriptive identifiers such as `"credit-card"` or `"paypal"`.