### PR TITLE
Fix concept-as dictionary key converter selection

### DIFF
--- a/Source/DotNET/Fundamentals.Specs/Json/for_ComplexKeyDictionaryJsonConverterFactory/when_serializing_and_deserializing_dictionary_with_concept_as_string_key.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_ComplexKeyDictionaryJsonConverterFactory/when_serializing_and_deserializing_dictionary_with_concept_as_string_key.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using Cratis.Concepts;
+
+namespace Cratis.Json.for_ComplexKeyDictionaryJsonConverterFactory;
+
+public class when_serializing_and_deserializing_dictionary_with_concept_as_string_key : Specification
+{
+    JsonSerializerOptions _options;
+    IDictionary<PropertyPath, int> _dictionary;
+    string _json;
+    IDictionary<PropertyPath, int> _deserialized;
+
+    void Establish()
+    {
+        _options = new JsonSerializerOptions
+        {
+            Converters =
+            {
+                new ComplexKeyDictionaryJsonConverterFactory(),
+                new EnumerableConceptAsJsonConverterFactory(),
+                new ConceptAsJsonConverterFactory()
+            }
+        };
+
+        _dictionary = new Dictionary<PropertyPath, int>
+        {
+            [new("spec.name")] = 1,
+            [new("spec.version")] = 2
+        };
+    }
+
+    void Because()
+    {
+        _json = JsonSerializer.Serialize(_dictionary, _options);
+        _deserialized = JsonSerializer.Deserialize<IDictionary<PropertyPath, int>>(_json, _options)!;
+    }
+
+    [Fact] void should_deserialize_all_items() => _deserialized.Count.ShouldEqual(2);
+    [Fact] void should_deserialize_first_item() => _deserialized[new PropertyPath("spec.name")].ShouldEqual(1);
+    [Fact] void should_deserialize_second_item() => _deserialized[new PropertyPath("spec.version")].ShouldEqual(2);
+
+    public record PropertyPath(string Value) : ConceptAs<string>(Value);
+}

--- a/Source/DotNET/Fundamentals.Specs/Json/for_EnumerableConceptAsJsonConverterFactory/when_asking_can_convert_for_dictionary_with_concept_key.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_EnumerableConceptAsJsonConverterFactory/when_asking_can_convert_for_dictionary_with_concept_key.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Concepts;
+
+namespace Cratis.Json.for_EnumerableConceptAsJsonConverterFactory;
+
+public class when_asking_can_convert_for_dictionary_with_concept_key : Specification
+{
+    bool _result;
+
+    void Because() => _result = new EnumerableConceptAsJsonConverterFactory().CanConvert(typeof(IDictionary<PropertyPath, int>));
+
+    [Fact] void should_not_be_able_to_convert() => _result.ShouldBeFalse();
+
+    public record PropertyPath(string Value) : ConceptAs<string>(Value);
+}

--- a/Source/DotNET/Fundamentals/Json/EnumerableConceptAsJsonConverterFactory.cs
+++ b/Source/DotNET/Fundamentals/Json/EnumerableConceptAsJsonConverterFactory.cs
@@ -15,7 +15,10 @@ public class EnumerableConceptAsJsonConverterFactory : JsonConverterFactory
 {
     /// <inheritdoc/>
     public override bool CanConvert(Type typeToConvert) =>
-        typeToConvert.IsEnumerable() && typeToConvert.IsGenericType && typeToConvert.GetGenericArguments()[0].IsConcept();
+        !typeToConvert.IsDictionary() &&
+        typeToConvert.IsEnumerable() &&
+        typeToConvert.IsGenericType &&
+        typeToConvert.GetGenericArguments()[0].IsConcept();
 
     /// <inheritdoc/>
     public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)


### PR DESCRIPTION
## Fixed
- Prevented concept-keyed dictionaries from being matched by the enumerable concept converter, avoiding incompatible converter assignment during serialization setup.
- Added regression specs for converter selection and JSON roundtrip of concept-as-string dictionary keys.