### PR TITLE
Fix derived type resolution and serialization in C# and TypeScript

### DIFF
--- a/Source/DotNET/Fundamentals/Serialization/DerivedTypes.cs
+++ b/Source/DotNET/Fundamentals/Serialization/DerivedTypes.cs
@@ -76,19 +76,17 @@ public class DerivedTypes : IDerivedTypes
     {
         var attribute = derivedType.GetCustomAttribute<DerivedTypeAttribute>()!;
         var targetType = attribute.TargetType;
-        var interfaces = derivedType.GetInterfaces().Where(_ => !_.Namespace?.StartsWith("System") ?? true).ToArray();
 
-        if (targetType is null)
+        if (targetType is not null)
         {
-            ThrowIfAmbiguousTargetTypeForDerivedType(derivedType, interfaces);
-            ThrowIfMissingTargetTypeForDerivedType(derivedType, interfaces);
-            targetType = interfaces[0];
+            ThrowIfTargetTypeMismatchesForDerivedType(derivedType, targetType);
+            return targetType;
         }
 
+        var interfaces = derivedType.GetInterfaces().Where(_ => !_.Namespace?.StartsWith("System") ?? true).ToArray();
+        ThrowIfAmbiguousTargetTypeForDerivedType(derivedType, interfaces);
         ThrowIfMissingTargetTypeForDerivedType(derivedType, interfaces);
-        ThrowIfTargetTypeMismatchesForDerivedType(derivedType, targetType, interfaces);
-
-        return targetType;
+        return interfaces[0];
     }
 
     void ThrowIfMissingDerivedTypeOrMissingIdentifier(Type targetType, DerivedTypeId derivedTypeId)
@@ -126,9 +124,9 @@ public class DerivedTypes : IDerivedTypes
         }
     }
 
-    void ThrowIfTargetTypeMismatchesForDerivedType(Type derivedType, Type? targetType, Type[] interfaces)
+    void ThrowIfTargetTypeMismatchesForDerivedType(Type derivedType, Type targetType)
     {
-        if (!interfaces.Any(_ => _ == targetType))
+        if (!derivedType.IsAssignableTo(targetType))
         {
             throw new TargetTypeMismatchForDerivedType(derivedType);
         }

--- a/Source/JavaScript/DerivedType.ts
+++ b/Source/JavaScript/DerivedType.ts
@@ -4,11 +4,22 @@
 import { Constructor } from './Constructor';
 
 export class DerivedType {
-    static set(target: Constructor, identifier: string) {
+    static set(target: Constructor, identifier: string, targetType?: Constructor) {
         Reflect.defineMetadata('derivedType', identifier, target);
+        if (targetType) {
+            const existing: Constructor[] = Reflect.getOwnMetadata('derivedTypes', targetType) ?? [];
+            if (!existing.includes(target)) {
+                existing.push(target);
+                Reflect.defineMetadata('derivedTypes', existing, targetType);
+            }
+        }
     }
 
     static get(target: Constructor): string {
         return Reflect.getOwnMetadata('derivedType', target);
+    }
+
+    static getDerivedTypesFor(targetType: Constructor): Constructor[] {
+        return Reflect.getOwnMetadata('derivedTypes', targetType) ?? [];
     }
 }

--- a/Source/JavaScript/JsonSerializer.ts
+++ b/Source/JavaScript/JsonSerializer.ts
@@ -66,9 +66,10 @@ const deserializeValueFromField = (field: Field, value: any) => {
         return typeSerializers.get(field.type)!(value);
     } else {
         let type = field.type;
-        if (field.derivatives.length > 0 && value[JsonSerializer.DerivedTypeIdProperty]) {
+        if (value[JsonSerializer.DerivedTypeIdProperty]) {
             const derivedTypeId = value[JsonSerializer.DerivedTypeIdProperty];
-            type = field.derivatives.find(_ => DerivedType.get(_) == derivedTypeId) || type;
+            const candidates = [...field.derivatives, ...DerivedType.getDerivedTypesFor(field.type)];
+            type = candidates.find(_ => DerivedType.get(_) == derivedTypeId) || type;
         }
 
         return JsonSerializer.deserialize(type, JSON.stringify(value));
@@ -156,6 +157,11 @@ const convertTypesOnInstance = (instance: any) => {
 
     const properties = Object.getOwnPropertyNames(instance);
     const converted: any = {};
+
+    const derivedTypeId = DerivedType.get(instance.constructor);
+    if (derivedTypeId) {
+        converted[JsonSerializer.DerivedTypeIdProperty] = derivedTypeId;
+    }
     properties.forEach(property => {
         let value = instance[property];
         if (value !== undefined) {

--- a/Source/JavaScript/derivedTypeDecorator.ts
+++ b/Source/JavaScript/derivedTypeDecorator.ts
@@ -2,13 +2,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import 'reflect-metadata';
+import { Constructor } from './Constructor';
 import { DerivedType } from './DerivedType';
 
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-export function derivedType(identifier: string) {
+export function derivedType(identifier: string, targetType?: Constructor) {
     return function (target: any) {
-        DerivedType.set(target, identifier);
+        DerivedType.set(target, identifier, targetType);
     };
 }


### PR DESCRIPTION
## Fixed
- Corrected target type resolution logic in `DerivedTypes` so that a known `targetType` is validated with `IsAssignableTo` and returned early, and the interface-based fallback only runs when `targetType` is null.
- TypeScript `derivedType` decorator now accepts an optional `targetType`, registering the decorated class against its base type for automatic discovery during deserialization.
- `JsonSerializer` deserialization now resolves derived types from both explicit field derivatives and types registered via `DerivedType.getDerivedTypesFor`, eliminating the need to list every subtype on every field.
- `JsonSerializer` serialization now writes the `_type` discriminator property automatically when the instance's constructor has a registered derived type identifier, ensuring derived type instances round-trip correctly.