### PR TITLE
Auto-register derived types with full prototype chain

### DIFF
--- a/Source/JavaScript/derivedTypeDecorator.ts
+++ b/Source/JavaScript/derivedTypeDecorator.ts
@@ -11,5 +11,14 @@ import { DerivedType } from './DerivedType';
 export function derivedType(identifier: string, targetType?: Constructor) {
     return function (target: any) {
         DerivedType.set(target, identifier, targetType);
+
+        // Auto-register with every class in the prototype chain so that JsonSerializer
+        // can discover all derived types via DerivedType.getDerivedTypesFor() at runtime,
+        // without requiring the parent type to import each subtype (which causes circular deps).
+        let proto = Object.getPrototypeOf(target.prototype);
+        while (proto && proto.constructor && proto.constructor !== Object) {
+            DerivedType.set(target, identifier, proto.constructor);
+            proto = Object.getPrototypeOf(proto);
+        }
     };
 }


### PR DESCRIPTION
## Fixed
- `derivedType` decorator now walks the full prototype chain and registers the decorated class against every ancestor type, enabling `JsonSerializer` to discover derived types without requiring explicit subtype imports (which cause circular dependencies).