### PR TITLE
Support derived type resolution for base-class polymorphism

### DIFF
--- a/Documentation/csharp/serialization/derived_types.md
+++ b/Documentation/csharp/serialization/derived_types.md
@@ -15,7 +15,10 @@ The DerivedTypes system consists of several key components:
 
 ### Target Types and Derived Types
 
-- **Target Type**: The interface or base class that defines the contract (e.g., `IPaymentMethod`)
+- **Primary Target Type**: The type used as the canonical registration key for a derived type.
+    By default this is the inferred non-system interface (or the explicit `targetType` if provided).
+- **Additional Target Types**: Non-system base classes are registered automatically so lookup can resolve
+    by base class without requiring explicit `targetType`.
 - **Derived Type**: The concrete implementation decorated with `[DerivedType]` (e.g., `CreditCard`, `PayPal`)
 
 ### Unique Identifiers
@@ -123,7 +126,13 @@ public class CreditCard : IPaymentMethod, IRefundable
 
 ### Target Type Resolution
 
-The system automatically resolves target types based on implemented interfaces. If a class implements only one interface decorated with derived types, that interface becomes the target type automatically.
+The system resolves a primary target type automatically from implemented non-system interfaces.
+If a class implements exactly one non-system interface, that interface becomes the primary target.
+If `targetType` is provided on `[DerivedType(..., targetType)]`, that value is used as the primary target.
+
+In addition to the primary target, the system now also registers the derived type for all non-system base
+classes in its inheritance chain. This means polymorphic deserialization can work when the property is typed
+as either an interface or a base class.
 
 ### Validation Rules
 
@@ -132,6 +141,7 @@ The system enforces several validation rules:
 1. **Unique Identifiers**: Each derived type must have a unique string identifier
 2. **Single Target Type**: A derived type can only represent one target interface
 3. **Interface Implementation**: Derived types must implement their declared target interface
+4. **Base Class Compatibility**: Derived types are also registered for non-system base classes automatically
 
 ## Error Handling
 

--- a/Documentation/derived_types_integration.md
+++ b/Documentation/derived_types_integration.md
@@ -8,6 +8,17 @@ The DerivedTypes system creates a bridge between strongly-typed C# classes and T
 
 ## Shared Concepts
 
+### Target Type Resolution Across Stacks
+
+- **Backend (.NET):** `[DerivedType]` resolves a primary target from interface inference (or explicit
+    `targetType`) and also auto-registers the derived type for non-system base classes.
+- **Frontend (TypeScript):** `@derivedType` registers identifiers on the concrete type and runtime
+    prototype chain constructors, and `JsonSerializer` resolves candidates from both
+    `field.derivatives` and `DerivedType.getDerivedTypesFor(field.type)`.
+
+This means polymorphic fields typed as base classes work end-to-end without requiring explicit target
+type wiring in most cases. Interface-only fields still need explicit runtime candidates.
+
 ### Unique Type Identifiers
 
 Both backend and frontend use unique string identifiers that must match exactly:
@@ -305,6 +316,15 @@ import 'reflect-metadata';
 ```
 
 ## Best Practices for Full-Stack Integration
+
+### Prefer Concrete Base Types for Polymorphic Properties
+
+When your domain has a stable base class, prefer using that base class as the property type.
+This gives runtime constructors on both stacks, which simplifies polymorphic resolution and reduces
+manual derivative wiring.
+
+Use interface-typed properties when needed, and then provide explicit derivative candidates in
+frontend field metadata and explicit target type where ambiguity exists.
 
 ### 1. Synchronized Type Definitions
 

--- a/Documentation/typescript/serialization/derived_types.md
+++ b/Documentation/typescript/serialization/derived_types.md
@@ -24,6 +24,20 @@ The frontend uses TypeScript decorators and reflect-metadata to store type infor
 - **Field Metadata**: Information about properties including their types and possible derivatives
 - **Runtime Type Resolution**: Dynamic instantiation of correct classes during deserialization
 
+### Runtime Resolution Behavior
+
+At runtime, the deserializer resolves derived types from two candidate sources:
+
+- `field.derivatives` provided by `@field(..., derivatives)`
+- Runtime registrations from `DerivedType.getDerivedTypesFor(field.type)`
+
+The runtime registrations are populated by the `@derivedType` decorator by walking the prototype chain.
+Because of this, class-based hierarchies (base class + subclasses) are discovered automatically.
+
+For interface-shaped polymorphism, remember that TypeScript interfaces are erased at runtime.
+In those cases, use explicit `field.derivatives`, or pass `targetType` to `@derivedType` so the
+type is registered against a concrete runtime constructor.
+
 ### Decorator-Based Configuration
 
 Unlike the backend's attribute-based approach, the frontend uses decorators to mark classes and fields with metadata.
@@ -105,6 +119,10 @@ export class Order {
     @field(Object, true, [CreditCard, PayPal])
     alternativePayments!: IPaymentMethod[];
 }
+
+If `paymentMethod` is typed as a concrete base class (instead of interface-only shape), runtime
+registration from `@derivedType` can often resolve the correct subtype without an explicit derivatives list.
+Keeping the list is still valid and can be useful for clarity.
 ```
 
 ## Serialization and Deserialization

--- a/Documentation/typescript/serialization/json_serializer.md
+++ b/Documentation/typescript/serialization/json_serializer.md
@@ -72,6 +72,16 @@ const payment = JsonSerializer.deserialize(Payment, json);
 console.log(payment.method instanceof CreditCard); // ✅ true
 ```
 
+The runtime resolution flow is:
+
+1. Read `_derivedTypeId` from the payload.
+2. Build candidates from both `field.derivatives` and `DerivedType.getDerivedTypesFor(field.type)`.
+3. Match candidate identifier and deserialize into the matching constructor.
+
+This makes class inheritance work with runtime-only registration from `@derivedType`.
+For interface-only polymorphism, include explicit derivatives on `@field` (or use `@derivedType`
+with an explicit `targetType` constructor).
+
 ### 4. Proper Type Conversion
 
 Complex types like `Date` and `Guid` are properly converted during deserialization:

--- a/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_checking_if_has_derivatives_for_known_base_type.cs
+++ b/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_checking_if_has_derivatives_for_known_base_type.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Serialization.for_DerivedTypes;
+
+public class when_checking_if_has_derivatives_for_known_base_type : given.derived_types
+{
+    interface ITargetType;
+
+    abstract record BaseType : ITargetType;
+
+    [DerivedType("known-type")]
+    record DerivedType : BaseType;
+
+    bool result;
+    DerivedTypes derived_types;
+
+    protected override IEnumerable<Type> ProvideDerivedTypes() => [typeof(DerivedType)];
+
+    void Establish() => derived_types = new(types.Object);
+
+    void Because() => result = derived_types.HasDerivatives(typeof(BaseType));
+
+    [Fact] void should_have_derivatives() => result.ShouldBeTrue();
+}

--- a/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_getting_known_derived_type_that_matches_base_class.cs
+++ b/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_getting_known_derived_type_that_matches_base_class.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Serialization.for_DerivedTypes;
+
+public class when_getting_known_derived_type_that_matches_base_class : given.derived_types
+{
+    interface ITargetType;
+
+    abstract record BaseType : ITargetType;
+
+    [DerivedType("known-type")]
+    record DerivedType : BaseType;
+
+    DerivedTypes derived_types;
+    Type result;
+
+    protected override IEnumerable<Type> ProvideDerivedTypes() => [typeof(DerivedType)];
+
+    void Establish() => derived_types = new DerivedTypes(types.Object);
+
+    void Because() => result = derived_types.GetDerivedTypeFor(typeof(BaseType), "known-type");
+
+    [Fact] void should_return_derived_type() => result.ShouldEqual(typeof(DerivedType));
+}

--- a/Source/DotNET/Fundamentals/Serialization/DerivedTypes.cs
+++ b/Source/DotNET/Fundamentals/Serialization/DerivedTypes.cs
@@ -33,15 +33,22 @@ public class DerivedTypes : IDerivedTypes
     /// <param name="types"><see cref="ITypes"/> representing all types in the system.</param>
     public DerivedTypes(ITypes types)
     {
-        var derivedTypes = types.All.Where(_ => _.HasAttribute<DerivedTypeAttribute>());
+        var derivedTypes = types.All.Where(_ => _.HasAttribute<DerivedTypeAttribute>()).ToArray();
         ThrowIfAmbiguousDerivedTypeIdentifiers(derivedTypes);
 
-        _targetTypeToDerivedType = derivedTypes
-            .GroupBy(GetTargetTypeFrom)
-            .ToDictionary(_ => _.Key, _ => _.Select(dt => new DerivedTypeAndIdentifier(dt, _.Key, dt.GetCustomAttribute<DerivedTypeAttribute>()!.Identifier)));
+        var registrations = derivedTypes
+            .SelectMany(GetRegistrationsFrom)
+            .ToArray();
 
-        _derivedTypeToTargetType = _targetTypeToDerivedType
-            .SelectMany(_ => _.Value)
+        _targetTypeToDerivedType = registrations
+            .GroupBy(_ => _.TargetType)
+            .ToDictionary(
+                _ => _.Key,
+                _ => _.GroupBy(registration => registration.DerivedType)
+                      .Select(group => new DerivedTypeAndIdentifier(group.Key, _.Key, group.First().Identifier)));
+
+        _derivedTypeToTargetType = registrations
+            .Where(_ => _.IsPrimaryTarget)
             .ToDictionary(_ => _.DerivedType, _ => _.TargetType);
     }
 
@@ -73,22 +80,43 @@ public class DerivedTypes : IDerivedTypes
     /// <inheritdoc/>
     public bool HasDerivatives(Type type) => _targetTypeToDerivedType.ContainsKey(type);
 
-    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Derived type interface inspection is retained for compatibility fallback behavior.")]
-    Type GetTargetTypeFrom(Type derivedType)
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Derived type interface and inheritance inspection is retained for compatibility fallback behavior.")]
+    IEnumerable<Registration> GetRegistrationsFrom(Type derivedType)
     {
         var attribute = derivedType.GetCustomAttribute<DerivedTypeAttribute>()!;
-        var targetType = attribute.TargetType;
+        var primaryTargetType = attribute.TargetType;
 
-        if (targetType is not null)
+        if (primaryTargetType is not null)
         {
-            ThrowIfTargetTypeMismatchesForDerivedType(derivedType, targetType);
-            return targetType;
+            var interfaces = derivedType.GetInterfaces().Where(_ => !_.Namespace?.StartsWith("System") ?? true).ToArray();
+            ThrowIfMissingTargetTypeForDerivedType(derivedType, interfaces);
+            ThrowIfTargetTypeMismatchesForDerivedType(derivedType, primaryTargetType);
+        }
+        else
+        {
+            var interfaces = derivedType.GetInterfaces().Where(_ => !_.Namespace?.StartsWith("System") ?? true).ToArray();
+            ThrowIfAmbiguousTargetTypeForDerivedType(derivedType, interfaces);
+            ThrowIfMissingTargetTypeForDerivedType(derivedType, interfaces);
+            primaryTargetType = interfaces[0];
         }
 
-        var interfaces = derivedType.GetInterfaces().Where(_ => !_.Namespace?.StartsWith("System") ?? true).ToArray();
-        ThrowIfAmbiguousTargetTypeForDerivedType(derivedType, interfaces);
-        ThrowIfMissingTargetTypeForDerivedType(derivedType, interfaces);
-        return interfaces[0];
+        var registrations = new List<Registration>
+        {
+            new(derivedType, primaryTargetType, attribute.Identifier, true)
+        };
+
+        var currentBaseType = derivedType.BaseType;
+        while (currentBaseType is not null && currentBaseType != typeof(object))
+        {
+            if (!currentBaseType.Namespace?.StartsWith("System") ?? true)
+            {
+                registrations.Add(new(derivedType, currentBaseType, attribute.Identifier, false));
+            }
+
+            currentBaseType = currentBaseType.BaseType;
+        }
+
+        return registrations;
     }
 
     void ThrowIfMissingDerivedTypeOrMissingIdentifier(Type targetType, DerivedTypeId derivedTypeId)
@@ -134,5 +162,6 @@ public class DerivedTypes : IDerivedTypes
         }
     }
 
+    sealed record Registration(Type DerivedType, Type TargetType, DerivedTypeId Identifier, bool IsPrimaryTarget);
     sealed record DerivedTypeAndIdentifier(Type DerivedType, Type TargetType, DerivedTypeId Identifier);
 }


### PR DESCRIPTION
## Changed
- Register derived types for non-system base classes in addition to the primary target type so polymorphic deserialization can resolve by base class without explicit targetType.
- Preserve existing validation semantics for ambiguous targets and target mismatches.

## Added
- Serialization specs covering base-class derived type lookup and HasDerivatives behavior for known base types.
- Documentation clarifying backend target resolution and frontend runtime candidate resolution from both field derivatives and runtime derived-type registry.
