### PR TITLE
Fix NuGet pack failure for spec projects

### DIFF
--- a/Source/DotNET/Fundamentals.AOT.Specs/Fundamentals.AOT.Specs.csproj
+++ b/Source/DotNET/Fundamentals.AOT.Specs/Fundamentals.AOT.Specs.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <IsTestProject>true</IsTestProject>
+        <IsPackable>false</IsPackable>
         <AssemblyName>Cratis.Fundamentals.AOT.Specs</AssemblyName>
         <RootNamespace>Cratis.Fundamentals.AOT.Specs</RootNamespace>
         <TargetFramework>net10.0</TargetFramework>

--- a/Source/DotNET/Fundamentals.TypeDiscovery.Generator.Specs/Fundamentals.TypeDiscovery.Generator.Specs.csproj
+++ b/Source/DotNET/Fundamentals.TypeDiscovery.Generator.Specs/Fundamentals.TypeDiscovery.Generator.Specs.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <IsTestProject>true</IsTestProject>
+        <IsPackable>false</IsPackable>
         <AssemblyName>Cratis.Fundamentals.TypeDiscovery.Generator.Specs</AssemblyName>
         <RootNamespace>Cratis.Fundamentals.TypeDiscovery.Generator.Specs</RootNamespace>
         <TargetFramework>net10.0</TargetFramework>


### PR DESCRIPTION
## Fixed
- Prevented release publishing failures by excluding internal spec projects from NuGet packaging so package generation completes without NU5026 errors.
