### PR TITLE
Fix source generator registering open generic types as their own implementors

### DIFF
--- a/Source/DotNET/Fundamentals.TypeDiscovery.Generator.Specs/for_NamedTypeSymbolExtensions/when_checking_if_is_implementation/and_type_is_an_open_generic_class.cs
+++ b/Source/DotNET/Fundamentals.TypeDiscovery.Generator.Specs/for_NamedTypeSymbolExtensions/when_checking_if_is_implementation/and_type_is_an_open_generic_class.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Fundamentals.TypeDiscovery.Generator.Specs;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Fundamentals.TypeDiscovery.Generator.for_NamedTypeSymbolExtensions.when_checking_if_is_implementation;
+
+public class and_type_is_an_open_generic_class : Specification
+{
+    INamedTypeSymbol _type;
+    bool _result;
+
+    void Establish() =>
+        _type = CompilationFactory.GetNamedTypes("public class Generic<T> { }").Single(t => t.Name == "Generic");
+
+    void Because() => _result = _type.IsImplementation();
+
+    [Fact] void should_return_false() => _result.ShouldBeFalse();
+}

--- a/Source/DotNET/Fundamentals.TypeDiscovery.Generator/NamedTypeSymbolExtensions.cs
+++ b/Source/DotNET/Fundamentals.TypeDiscovery.Generator/NamedTypeSymbolExtensions.cs
@@ -35,7 +35,8 @@ internal static class NamedTypeSymbolExtensions
     /// <returns><see langword="true"/> if the type is a concrete implementation; otherwise <see langword="false"/>.</returns>
     public static bool IsImplementation(this INamedTypeSymbol type) =>
         type.TypeKind is not TypeKind.Interface &&
-        !type.IsAbstract;
+        !type.IsAbstract &&
+        type.Arity == 0;
 
     /// <summary>
     /// Returns the C# <c>typeof()</c> argument expression for this type.


### PR DESCRIPTION
## Fixed
- Open generic types (e.g. `ConceptAs<T>`, `ConceptAsTypeConverter<T,U>`) were incorrectly included in the generated type-discovery provider as implementors of themselves. At runtime this caused `ArgumentException: The type 'System.Void' may not be used as a type argument` during startup when registering type converters for concepts.