### PR TITLE
Include PackageReferencedAssemblies when generated providers are present

### DIFF
--- a/Source/DotNET/Fundamentals.Specs/Types/for_Types/when_generated_provider_is_registered_alongside_a_plain_assembly_provider.cs
+++ b/Source/DotNET/Fundamentals.Specs/Types/for_Types/when_generated_provider_is_registered_alongside_a_plain_assembly_provider.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+namespace Cratis.Types.for_Types;
+
+public class when_generated_provider_is_registered_alongside_a_plain_assembly_provider : Specification
+{
+    Type[] _implementors;
+
+    void Because() => _implementors =
+    [
+        ..new Types([new for_GeneratedTypeDiscoveryRegistry.a_provider(), new plain_assembly_provider()])
+            .FindMultiple<IPackageOnlyInterface>()
+    ];
+
+    [Fact] void should_discover_types_from_the_plain_assembly_provider() => _implementors.ShouldContainOnly(typeof(PackageOnlyImplementation));
+}
+
+public interface IPackageOnlyInterface;
+
+public class PackageOnlyImplementation : IPackageOnlyInterface;
+
+class plain_assembly_provider : ICanProvideAssembliesForDiscovery
+{
+    public IEnumerable<Assembly> Assemblies => [typeof(plain_assembly_provider).Assembly];
+
+    public IEnumerable<Type> DefinedTypes => [typeof(IPackageOnlyInterface), typeof(PackageOnlyImplementation)];
+
+    public void Initialize()
+    {
+    }
+}

--- a/Source/DotNET/Fundamentals/Types/Types.cs
+++ b/Source/DotNET/Fundamentals/Types/Types.cs
@@ -33,7 +33,7 @@ public class Types : ITypes
     public Types()
         : this(
             GeneratedTypeDiscoveryRegistry.Providers.Any()
-                ? GeneratedTypeDiscoveryRegistry.Providers
+                ? [.. GeneratedTypeDiscoveryRegistry.Providers, PackageReferencedAssemblies.Instance]
                 :
                 [
                     ProjectReferencedAssemblies.Instance,

--- a/Source/DotNET/Fundamentals/Types/TypesServiceCollectionExtensions.cs
+++ b/Source/DotNET/Fundamentals/Types/TypesServiceCollectionExtensions.cs
@@ -22,7 +22,7 @@ public static class TypesServiceCollectionExtensions
         {
             var generatedProviders = GeneratedTypeDiscoveryRegistry.Providers.ToArray();
             assemblyProviders = generatedProviders.Length > 0
-                ? generatedProviders
+                ? [.. generatedProviders, PackageReferencedAssemblies.Instance]
                 :
                 [
                     ProjectReferencedAssemblies.Instance,


### PR DESCRIPTION
## Fixed

- `Types` and `AddTypeDiscovery` now always include `PackageReferencedAssemblies` alongside any generated type discovery providers, ensuring that NuGet packages without their own source-generated provider (e.g. `Cratis.Arc.*`, `Cratis.Chronicle.*`) are still visible to the type system and DI convention binding works correctly.