### PR TITLE
Fix TypeDiscovery generator emitting inaccessible types as contracts

### DIFF
--- a/Source/DotNET/Fundamentals.TypeDiscovery.Generator.Specs/for_TypeDiscoveryCollector/when_getting_contracts_and_implementors/and_there_are_multiple_implementors_for_one_interface.cs
+++ b/Source/DotNET/Fundamentals.TypeDiscovery.Generator.Specs/for_TypeDiscoveryCollector/when_getting_contracts_and_implementors/and_there_are_multiple_implementors_for_one_interface.cs
@@ -9,20 +9,22 @@ namespace Cratis.Fundamentals.TypeDiscovery.Generator.for_TypeDiscoveryCollector
 public class and_there_are_multiple_implementors_for_one_interface : Specification
 {
     INamedTypeSymbol[] _symbols;
+    IAssemblySymbol _assembly;
     System.Collections.Immutable.ImmutableArray<string> _implementors;
 
-    void Establish() =>
-        _symbols =
-        [
-            .. CompilationFactory.GetNamedTypes(
-                "namespace App;\n" +
-                "public interface IHandler { }\n" +
-                "public class HandlerA : IHandler { }\n" +
-                "public class HandlerB : IHandler { }")
-        ];
+    void Establish()
+    {
+        var compilation = CompilationFactory.CreateCompilation(
+            "namespace App;\n" +
+            "public interface IHandler { }\n" +
+            "public class HandlerA : IHandler { }\n" +
+            "public class HandlerB : IHandler { }");
+        _assembly = compilation.Assembly;
+        _symbols = [.. compilation.Assembly.GlobalNamespace.GetAllNamedTypes()];
+    }
 
     void Because() =>
-        _implementors = TypeDiscoveryCollector.GetContractsAndImplementors(_symbols)
+        _implementors = TypeDiscoveryCollector.GetContractsAndImplementors(_symbols, _assembly)
             .Single(e => e.ContractExpression == "global::App.IHandler")
             .ImplementorExpressions;
 

--- a/Source/DotNET/Fundamentals.TypeDiscovery.Generator.Specs/for_TypeDiscoveryCollector/when_getting_contracts_and_implementors/and_there_is_one_implementor_per_interface.cs
+++ b/Source/DotNET/Fundamentals.TypeDiscovery.Generator.Specs/for_TypeDiscoveryCollector/when_getting_contracts_and_implementors/and_there_is_one_implementor_per_interface.cs
@@ -9,18 +9,20 @@ namespace Cratis.Fundamentals.TypeDiscovery.Generator.for_TypeDiscoveryCollector
 public class and_there_is_one_implementor_per_interface : Specification
 {
     INamedTypeSymbol[] _symbols;
+    IAssemblySymbol _assembly;
     (string ContractExpression, System.Collections.Immutable.ImmutableArray<string> ImplementorExpressions)[] _result;
 
-    void Establish() =>
-        _symbols =
-        [
-            .. CompilationFactory.GetNamedTypes(
-                "namespace App;\n" +
-                "public interface IFoo { }\n" +
-                "public class Foo : IFoo { }")
-        ];
+    void Establish()
+    {
+        var compilation = CompilationFactory.CreateCompilation(
+            "namespace App;\n" +
+            "public interface IFoo { }\n" +
+            "public class Foo : IFoo { }");
+        _assembly = compilation.Assembly;
+        _symbols = [.. compilation.Assembly.GlobalNamespace.GetAllNamedTypes()];
+    }
 
-    void Because() => _result = [.. TypeDiscoveryCollector.GetContractsAndImplementors(_symbols)];
+    void Because() => _result = [.. TypeDiscoveryCollector.GetContractsAndImplementors(_symbols, _assembly)];
 
     [Fact] void should_include_the_interface_as_a_contract() => _result.Select(e => e.ContractExpression).ShouldContain("global::App.IFoo");
     [Fact] void should_map_the_class_as_the_implementor() =>

--- a/Source/DotNET/Fundamentals.TypeDiscovery.Generator/NamedTypeSymbolExtensions.cs
+++ b/Source/DotNET/Fundamentals.TypeDiscovery.Generator/NamedTypeSymbolExtensions.cs
@@ -30,6 +30,32 @@ internal static class NamedTypeSymbolExtensions
         type.DeclaredAccessibility is not Accessibility.Private;
 
     /// <summary>
+    /// Returns whether the type is declared entirely within auto-generated source files
+    /// produced by another source generator (files whose path ends with <c>.g.cs</c>).
+    /// Such types must be excluded from the type-discovery output to prevent CS0436
+    /// conflicts when the same type name is also imported from a referenced assembly.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns><see langword="true"/> if every declaring syntax reference is in a <c>.g.cs</c> file; otherwise <see langword="false"/>.</returns>
+    public static bool IsFromSourceGenerator(this INamedTypeSymbol type) =>
+        type.DeclaringSyntaxReferences.Length > 0 &&
+        type.DeclaringSyntaxReferences.All(
+            r => r.SyntaxTree.FilePath.EndsWith(".g.cs", StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// Returns whether the type is accessible from code generated into <paramref name="assembly"/>.
+    /// Types from the same assembly may be <see langword="internal"/> or more visible.
+    /// Types from external assemblies must be <see langword="public"/>.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <param name="assembly">The assembly into which generated code will be emitted.</param>
+    /// <returns><see langword="true"/> if the type is accessible; otherwise <see langword="false"/>.</returns>
+    public static bool IsAccessibleFromAssembly(this INamedTypeSymbol type, IAssemblySymbol assembly) =>
+        SymbolEqualityComparer.Default.Equals(type.ContainingAssembly, assembly)
+            ? type.DeclaredAccessibility is not Accessibility.Private
+            : type.DeclaredAccessibility is Accessibility.Public;
+
+    /// <summary>
     /// Returns whether the type is a concrete implementation — not an interface or abstract class.
     /// </summary>
     /// <param name="type">The type to check.</param>
@@ -140,17 +166,20 @@ internal static class NamedTypeSymbolExtensions
     /// <summary>
     /// Returns all base types and implemented interface types for the given type,
     /// including their open-generic forms where applicable.
-    /// Excludes <c>System.Object</c> and the type itself.
+    /// Excludes <c>System.Object</c>, the type itself, and any contracts that are not
+    /// accessible from generated code emitted into <paramref name="currentAssembly"/>
+    /// (i.e. internal types from external assemblies are excluded to prevent CS0122).
     /// </summary>
     /// <param name="type">The type to inspect.</param>
+    /// <param name="currentAssembly">The assembly into which generated code will be emitted.</param>
     /// <returns>The set of all contracts the type fulfils.</returns>
-    public static IEnumerable<INamedTypeSymbol> GetAllBaseAndImplementingSymbols(this INamedTypeSymbol type) =>
+    public static IEnumerable<INamedTypeSymbol> GetAllBaseAndImplementingSymbols(this INamedTypeSymbol type, IAssemblySymbol currentAssembly) =>
         type.GetBaseTypes()
             .Concat(type.AllInterfaces)
             .SelectMany(GetThisAndMaybeOpenType)
             .Where(t => !SymbolEqualityComparer.Default.Equals(t, type) && t.SpecialType != SpecialType.System_Object)
             .Distinct(NamedTypeSymbolComparer.Instance)
-            .Where(t => t.CanBeReferencedFromGeneratedCode());
+            .Where(t => t.IsAccessibleFromAssembly(currentAssembly));
 
     /// <summary>
     /// Enumerates the type itself and all of its base types up the inheritance chain.

--- a/Source/DotNET/Fundamentals.TypeDiscovery.Generator/TypeDiscoveryCollector.cs
+++ b/Source/DotNET/Fundamentals.TypeDiscovery.Generator/TypeDiscoveryCollector.cs
@@ -15,11 +15,15 @@ internal static class TypeDiscoveryCollector
     /// <summary>
     /// Builds the contract-to-implementors map for all concrete types in <paramref name="symbols"/>.
     /// Each entry maps a contract type expression to the expressions of all types that implement it.
+    /// Contracts from external assemblies that are not <see langword="public"/> are excluded to prevent CS0122
+    /// errors in the generated code.
     /// </summary>
     /// <param name="symbols">The set of named type symbols from the assembly.</param>
+    /// <param name="currentAssembly">The assembly into which generated code will be emitted.</param>
     /// <returns>One entry per contract with its ordered list of implementors.</returns>
     public static IEnumerable<(string ContractExpression, ImmutableArray<string> ImplementorExpressions)> GetContractsAndImplementors(
-        IEnumerable<INamedTypeSymbol> symbols)
+        IEnumerable<INamedTypeSymbol> symbols,
+        IAssemblySymbol currentAssembly)
     {
         var implementors = symbols.Where(s => s.IsImplementation()).ToArray();
         var contractsAndImplementors = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
@@ -28,7 +32,7 @@ internal static class TypeDiscoveryCollector
         {
             var implementorExpression = implementor.GetTypeOfExpression();
 
-            foreach (var contractExpression in implementor.GetAllBaseAndImplementingSymbols().Select(c => c.GetTypeOfExpression()))
+            foreach (var contractExpression in implementor.GetAllBaseAndImplementingSymbols(currentAssembly).Select(c => c.GetTypeOfExpression()))
             {
                 if (!contractsAndImplementors.TryGetValue(contractExpression, out var mapped))
                 {

--- a/Source/DotNET/Fundamentals.TypeDiscovery.Generator/TypeDiscoverySourceGenerator.cs
+++ b/Source/DotNET/Fundamentals.TypeDiscovery.Generator/TypeDiscoverySourceGenerator.cs
@@ -30,6 +30,7 @@ public sealed class TypeDiscoverySourceGenerator : IIncrementalGenerator
         var symbols = compilation.Assembly.GlobalNamespace
             .GetAllNamedTypes()
             .Where(s => s.CanBeReferencedFromGeneratedCode() &&
+                        !s.IsFromSourceGenerator() &&
                         !SymbolEqualityComparer.Default.Equals(s, entryPointContainerType))
             .ToImmutableArray();
 
@@ -39,7 +40,7 @@ public sealed class TypeDiscoverySourceGenerator : IIncrementalGenerator
             .OrderBy(static name => name, StringComparer.Ordinal)
             .ToImmutableArray();
 
-        var contractsAndImplementors = TypeDiscoveryCollector.GetContractsAndImplementors(symbols)
+        var contractsAndImplementors = TypeDiscoveryCollector.GetContractsAndImplementors(symbols, compilation.Assembly)
             .OrderBy(static e => e.ContractExpression, StringComparer.Ordinal)
             .ToImmutableArray();
 


### PR DESCRIPTION
## Fixed
- TypeDiscovery source generator no longer emits CS0436 warnings caused by types from other source generators (e.g. `GenerateOneOfAttribute` from `OneOf.SourceGenerator`) appearing in the generated type list.
- TypeDiscovery source generator no longer emits CS0122 errors caused by internal types from external assemblies (e.g. Orleans' `ISystemTargetBase`, `IRingRangeListener`, `IGrainCallCancellationExtension`, `IGrainTimerRegistry`) being included as contract keys in the generated discovery map.