### PR TITLE
Fix TypeDiscovery generator CS0436 and CS0433 conflicts from shared type names

### DIFF
--- a/Source/DotNET/Fundamentals.TypeDiscovery.Generator/TypeDiscoveryCollector.cs
+++ b/Source/DotNET/Fundamentals.TypeDiscovery.Generator/TypeDiscoveryCollector.cs
@@ -16,14 +16,20 @@ internal static class TypeDiscoveryCollector
     /// Builds the contract-to-implementors map for all concrete types in <paramref name="symbols"/>.
     /// Each entry maps a contract type expression to the expressions of all types that implement it.
     /// Contracts from external assemblies that are not <see langword="public"/> are excluded to prevent CS0122
-    /// errors in the generated code.
+    /// errors in the generated code. Contracts whose FQDN appears in more than one referenced assembly are
+    /// excluded to prevent CS0433 errors in the generated code.
     /// </summary>
     /// <param name="symbols">The set of named type symbols from the assembly.</param>
     /// <param name="currentAssembly">The assembly into which generated code will be emitted.</param>
+    /// <param name="ambiguousFqdns">
+    /// Optional set of fully-qualified type name expressions that exist in more than one referenced assembly.
+    /// Contracts whose expression appears in this set are omitted from the output to avoid CS0433.
+    /// </param>
     /// <returns>One entry per contract with its ordered list of implementors.</returns>
     public static IEnumerable<(string ContractExpression, ImmutableArray<string> ImplementorExpressions)> GetContractsAndImplementors(
         IEnumerable<INamedTypeSymbol> symbols,
-        IAssemblySymbol currentAssembly)
+        IAssemblySymbol currentAssembly,
+        HashSet<string>? ambiguousFqdns = null)
     {
         var implementors = symbols.Where(s => s.IsImplementation()).ToArray();
         var contractsAndImplementors = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
@@ -32,7 +38,9 @@ internal static class TypeDiscoveryCollector
         {
             var implementorExpression = implementor.GetTypeOfExpression();
 
-            foreach (var contractExpression in implementor.GetAllBaseAndImplementingSymbols(currentAssembly).Select(c => c.GetTypeOfExpression()))
+            foreach (var contractExpression in implementor.GetAllBaseAndImplementingSymbols(currentAssembly)
+                .Select(c => c.GetTypeOfExpression())
+                .Where(fqdn => ambiguousFqdns?.Contains(fqdn) is not true))
             {
                 if (!contractsAndImplementors.TryGetValue(contractExpression, out var mapped))
                 {

--- a/Source/DotNET/Fundamentals.TypeDiscovery.Generator/TypeDiscoverySourceGenerator.cs
+++ b/Source/DotNET/Fundamentals.TypeDiscovery.Generator/TypeDiscoverySourceGenerator.cs
@@ -27,10 +27,37 @@ public sealed class TypeDiscoverySourceGenerator : IIncrementalGenerator
         // name conflicts with Program classes in referenced assemblies, producing CS0436.
         var entryPointContainerType = compilation.GetEntryPoint(CancellationToken.None)?.ContainingType;
 
+        // Group all public types from every referenced assembly by their fully-qualified name so we can
+        // detect two categories of conflict before emitting typeof() expressions:
+        //   CS0436 — a type in the current assembly shares a FQDN with a type in a referenced assembly.
+        //   CS0433 — a FQDN appears in more than one referenced assembly (ambiguous reference).
+        var referencedTypesByFqdn = compilation.References
+            .Select(r => compilation.GetAssemblyOrModuleSymbol(r) as IAssemblySymbol)
+            .Where(static a => a is not null)
+            .Cast<IAssemblySymbol>()
+            .SelectMany(static a => a.GlobalNamespace.GetAllNamedTypes()
+                .Where(static s => s.DeclaredAccessibility == Accessibility.Public)
+                .Select(s => (Fqdn: s.GetTypeOfExpression(), AssemblyName: a.Name)))
+            .ToLookup(static x => x.Fqdn, StringComparer.Ordinal);
+
+        // FQDNs present in any referenced assembly — used to suppress CS0436 for current-assembly types.
+        var referencedFqdns = new HashSet<string>(
+            referencedTypesByFqdn.Select(static g => g.Key),
+            StringComparer.Ordinal);
+
+        // FQDNs present in more than one referenced assembly — used to suppress CS0433 for contracts
+        // and convention bindings that the compiler cannot resolve unambiguously.
+        var ambiguousFqdns = new HashSet<string>(
+            referencedTypesByFqdn
+                .Where(static g => g.Select(static x => x.AssemblyName).Distinct(StringComparer.Ordinal).Count() > 1)
+                .Select(static g => g.Key),
+            StringComparer.Ordinal);
+
         var symbols = compilation.Assembly.GlobalNamespace
             .GetAllNamedTypes()
             .Where(s => s.CanBeReferencedFromGeneratedCode() &&
                         !s.IsFromSourceGenerator() &&
+                        !referencedFqdns.Contains(s.GetTypeOfExpression()) &&
                         !SymbolEqualityComparer.Default.Equals(s, entryPointContainerType))
             .ToImmutableArray();
 
@@ -40,7 +67,7 @@ public sealed class TypeDiscoverySourceGenerator : IIncrementalGenerator
             .OrderBy(static name => name, StringComparer.Ordinal)
             .ToImmutableArray();
 
-        var contractsAndImplementors = TypeDiscoveryCollector.GetContractsAndImplementors(symbols, compilation.Assembly)
+        var contractsAndImplementors = TypeDiscoveryCollector.GetContractsAndImplementors(symbols, compilation.Assembly, ambiguousFqdns)
             .OrderBy(static e => e.ContractExpression, StringComparer.Ordinal)
             .ToImmutableArray();
 
@@ -58,12 +85,13 @@ public sealed class TypeDiscoverySourceGenerator : IIncrementalGenerator
             .Where(static a => !a.Modules.Any(static m => m.ReferencedAssemblies.Any(
                 static r => r.Name.StartsWith("Microsoft.CodeAnalysis", StringComparison.Ordinal))))
             .SelectMany(static a => a.GlobalNamespace.GetAllNamedTypes())
-            .Where(static s =>
+            .Where(s =>
                 s.DeclaredAccessibility == Accessibility.Public &&
                 !s.IsImplicitlyDeclared &&
                 !s.IsAnonymousType &&
                 !s.IsFileLocal &&
-                s.CanBeReferencedByName)
+                s.CanBeReferencedByName &&
+                !ambiguousFqdns.Contains(s.GetTypeOfExpression()))
             .ToImmutableArray();
 
         var conventionServiceBindings = TypeDiscoveryCollector.GetConventionServiceBindings(symbols)


### PR DESCRIPTION
## Fixed
- TypeDiscovery source generator no longer emits CS0436 warnings when the current assembly defines a type whose fully-qualified name also exists in a referenced assembly (e.g. `GrainExtensions` vs Orleans, `Program` vs `Cratis.Chronicle.Api`).
- TypeDiscovery source generator no longer emits CS0433 errors when the same fully-qualified name exists in more than one referenced assembly (e.g. `IPIIManager`, `Constraints`, `AppendResult` duplicated across `Cratis.Chronicle.Core` and `Cratis.Chronicle`).