### PR TITLE
Pin Microsoft.Extensions packages per target framework for net8.0 / net9.0

### DIFF
--- a/Directory.Packages.NET8.props
+++ b/Directory.Packages.NET8.props
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <ItemGroup>
+        <PackageVersion Update="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+        <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+        <PackageVersion Update="Microsoft.Extensions.DependencyModel" Version="8.0.2" />
+        <PackageVersion Update="System.Text.Json" Version="9.0.13" Condition="'$(IsTestProject)' != 'true'" />
+    </ItemGroup>
+</Project>

--- a/Directory.Packages.NET9.props
+++ b/Directory.Packages.NET9.props
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <ItemGroup>
+        <PackageVersion Update="Microsoft.Extensions.DependencyInjection" Version="9.0.13" />
+        <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.13" />
         <PackageVersion Update="Microsoft.Extensions.DependencyModel" Version="9.0.13" />
         <PackageVersion Update="System.Text.Json" Version="9.0.13" Condition="'$(IsTestProject)' != 'true'" />
     </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,9 +25,11 @@
     <PackageVersion Include="moq" Version="4.20.72" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.8" />
     <PackageVersion Include="System.Text.Json" Version="10.0.8" />
     <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
   </ItemGroup>
-  <Import Project="$(MSBuildThisFileDirectory)/Directory.Packages.NET8-9.props" Condition=" '$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' " />
+  <Import Project="$(MSBuildThisFileDirectory)/Directory.Packages.NET8.props" Condition=" '$(TargetFramework)' == 'net8.0' " />
+  <Import Project="$(MSBuildThisFileDirectory)/Directory.Packages.NET9.props" Condition=" '$(TargetFramework)' == 'net9.0' " />
 </Project>


### PR DESCRIPTION
## Fixed
- `CS1705` raised in downstream consumers targeting `net8.0` or `net9.0` because the produced Cratis.Fundamentals assemblies referenced `Microsoft.Extensions.DependencyInjection.Abstractions` 10.x for every target framework. `Microsoft.Extensions.DependencyInjection`, `Microsoft.Extensions.DependencyInjection.Abstractions`, and `Microsoft.Extensions.DependencyModel` are now pinned per TFM (8.0.x for `net8.0`, 9.0.13 for `net9.0`, 10.0.8 for `net10.0`).