### PR TITLE
Exclude build-time-only NuGet assemblies from type discovery

### DIFF
--- a/Source/DotNET/Fundamentals.TypeDiscovery.Generator.Specs/for_TypeDiscoverySourceGenerator/when_collecting_package_symbols/and_the_assembly_is_under_a_nuget_analyzers_folder.cs
+++ b/Source/DotNET/Fundamentals.TypeDiscovery.Generator.Specs/for_TypeDiscoverySourceGenerator/when_collecting_package_symbols/and_the_assembly_is_under_a_nuget_analyzers_folder.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Fundamentals.TypeDiscovery.Generator.for_TypeDiscoverySourceGenerator.when_collecting_package_symbols;
+
+/// <summary>
+/// Verifies that assemblies loaded from a NuGet <c>analyzers/</c> folder (Roslyn analyzer or
+/// source generator packages) are excluded from the generated package symbols, because their
+/// DLLs are not copied to the consuming project's runtime output.
+/// </summary>
+public class and_the_assembly_is_under_a_nuget_analyzers_folder : given.a_compilation_referencing_a_cratis_assembly
+{
+    void Because() => RunGeneratorWithAssemblyAt("analyzers/dotnet/cs");
+
+    [Fact] void should_not_report_diagnostics() => _result.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_produce_generated_source() => _generatedSource.ShouldNotBeEmpty();
+    [Fact] void should_include_the_current_assembly_type() => _generatedSource.ShouldContain("typeof(global::App.MyApp)");
+    [Fact] void should_not_include_service_interface_from_analyzer_assembly() =>
+        _generatedSource.ShouldNotContain("Cratis.BuildOnly.IBuildOnlyService");
+    [Fact] void should_not_include_implementation_type_from_analyzer_assembly() =>
+        _generatedSource.ShouldNotContain("Cratis.BuildOnly.BuildOnlyService");
+}

--- a/Source/DotNET/Fundamentals.TypeDiscovery.Generator.Specs/for_TypeDiscoverySourceGenerator/when_collecting_package_symbols/and_the_assembly_is_under_a_nuget_tasks_folder.cs
+++ b/Source/DotNET/Fundamentals.TypeDiscovery.Generator.Specs/for_TypeDiscoverySourceGenerator/when_collecting_package_symbols/and_the_assembly_is_under_a_nuget_tasks_folder.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Fundamentals.TypeDiscovery.Generator.for_TypeDiscoverySourceGenerator.when_collecting_package_symbols;
+
+/// <summary>
+/// Verifies that assemblies loaded from a NuGet <c>tasks/</c> folder (MSBuild task helpers
+/// such as Cratis.Arc.ProxyGenerator.Build) are excluded from the generated package symbols,
+/// because their DLLs are not copied to the consuming project's runtime output.
+/// </summary>
+public class and_the_assembly_is_under_a_nuget_tasks_folder : given.a_compilation_referencing_a_cratis_assembly
+{
+    void Because() => RunGeneratorWithAssemblyAt("tasks/net10.0");
+
+    [Fact] void should_not_report_diagnostics() => _result.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_produce_generated_source() => _generatedSource.ShouldNotBeEmpty();
+    [Fact] void should_include_the_current_assembly_type() => _generatedSource.ShouldContain("typeof(global::App.MyApp)");
+    [Fact] void should_not_include_service_interface_from_build_assembly() =>
+        _generatedSource.ShouldNotContain("Cratis.BuildOnly.IBuildOnlyService");
+    [Fact] void should_not_include_implementation_type_from_build_assembly() =>
+        _generatedSource.ShouldNotContain("Cratis.BuildOnly.BuildOnlyService");
+}

--- a/Source/DotNET/Fundamentals.TypeDiscovery.Generator.Specs/for_TypeDiscoverySourceGenerator/when_collecting_package_symbols/given/a_compilation_referencing_a_cratis_assembly.cs
+++ b/Source/DotNET/Fundamentals.TypeDiscovery.Generator.Specs/for_TypeDiscoverySourceGenerator/when_collecting_package_symbols/given/a_compilation_referencing_a_cratis_assembly.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Fundamentals.TypeDiscovery.Generator.Specs;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Cratis.Fundamentals.TypeDiscovery.Generator.for_TypeDiscoverySourceGenerator.when_collecting_package_symbols.given;
+
+/// <summary>
+/// Builds an in-memory Cratis.BuildOnly assembly with a public service interface/implementation pair
+/// that the generator would normally emit convention bindings for. Each derived spec materializes
+/// the assembly under a different NuGet folder convention to verify that the path-based filter
+/// excludes build-time-only references.
+/// </summary>
+public class a_compilation_referencing_a_cratis_assembly : Specification
+{
+    protected GeneratorDriverRunResult _result;
+    protected string _generatedSource;
+    string _tempDir;
+    byte[] _assemblyBytes;
+
+    void Establish()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+
+        using var stream = new MemoryStream();
+        var emitResult = CSharpCompilation.Create(
+            "Cratis.BuildOnly",
+            [CSharpSyntaxTree.ParseText("namespace Cratis.BuildOnly { public interface IBuildOnlyService { } public class BuildOnlyService : IBuildOnlyService { } }")],
+            [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)],
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+            .Emit(stream);
+
+        if (!emitResult.Success)
+        {
+            throw new InvalidOperationException("Failed to emit in-memory Cratis.BuildOnly assembly.");
+        }
+
+        _assemblyBytes = stream.ToArray();
+    }
+
+    void Destroy()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Writes the in-memory assembly to <paramref name="relativeFolder"/> under a fresh temp directory,
+    /// builds a compilation that references it from that path, runs the generator, and captures the result.
+    /// </summary>
+    /// <param name="relativeFolder">The relative folder (e.g. <c>tasks/net10.0</c>) under which to materialize the assembly.</param>
+    protected void RunGeneratorWithAssemblyAt(string relativeFolder)
+    {
+        var directory = Path.Combine(_tempDir, relativeFolder);
+        Directory.CreateDirectory(directory);
+        var dllPath = Path.Combine(directory, "Cratis.BuildOnly.dll");
+        File.WriteAllBytes(dllPath, _assemblyBytes);
+
+        var assemblyReference = MetadataReference.CreateFromFile(dllPath);
+        var baseCompilation = CompilationFactory.CreateCompilation("namespace App { public class MyApp { } }");
+        var compilation = CSharpCompilation.Create(
+            baseCompilation.AssemblyName,
+            baseCompilation.SyntaxTrees,
+            [.. baseCompilation.References, assemblyReference],
+            baseCompilation.Options);
+
+        _result = CSharpGeneratorDriver.Create(new TypeDiscoverySourceGenerator())
+            .RunGenerators(compilation)
+            .GetRunResult();
+        _generatedSource = _result.GeneratedTrees.SingleOrDefault()?.GetText().ToString() ?? string.Empty;
+    }
+}

--- a/Source/DotNET/Fundamentals.TypeDiscovery.Generator/TypeDiscoverySourceGenerator.cs
+++ b/Source/DotNET/Fundamentals.TypeDiscovery.Generator/TypeDiscoverySourceGenerator.cs
@@ -94,15 +94,22 @@ public sealed class TypeDiscoverySourceGenerator : IIncrementalGenerator
         // These packages do not ship their own generated provider, so their I<X>/X pairs
         // would otherwise be invisible once the generated path is taken (bypassing the
         // reflection fallback that previously discovered them).
-        // Assemblies that themselves reference Microsoft.CodeAnalysis are Roslyn analyzer
-        // packages (e.g. Cratis.Metrics.Roslyn). Their types cannot be instantiated at
-        // runtime without CodeAnalysis.dll in the output, so they are excluded.
+        //
+        // We must exclude references that do not produce a runtime assembly in the consuming
+        // project's output, because emitting typeof() for their types causes
+        // FileNotFoundException at runtime. Two independent signals are checked:
+        //   1. NuGet folder convention — runtime libraries live under lib/<tfm>/. Assemblies
+        //      loaded from tasks/ (MSBuild tasks, e.g. Cratis.Arc.ProxyGenerator.Build) or
+        //      analyzers/ (Roslyn analyzers) are build-time only.
+        //   2. Defense-in-depth for in-tree analyzers that have not yet been NuGet-packaged
+        //      (e.g. Cratis.Metrics.Roslyn during local development) — any assembly that
+        //      references Microsoft.CodeAnalysis cannot be instantiated at runtime without
+        //      CodeAnalysis.dll in the output.
         var packageSymbols = globallyAccessibleReferences
             .Select(r => compilation.GetAssemblyOrModuleSymbol(r) as IAssemblySymbol)
             .Where(static a => a?.Name.StartsWith("Cratis", StringComparison.Ordinal) is true)
             .Cast<IAssemblySymbol>()
-            .Where(static a => !a.Modules.Any(static m => m.ReferencedAssemblies.Any(
-                static r => r.Name.StartsWith("Microsoft.CodeAnalysis", StringComparison.Ordinal))))
+            .Where(a => !IsBuildTimeOnlyAssembly(compilation, a))
             .SelectMany(static a => a.GlobalNamespace.GetAllNamedTypes())
             .Where(s =>
                 s.DeclaredAccessibility == Accessibility.Public &&
@@ -129,5 +136,26 @@ public sealed class TypeDiscoverySourceGenerator : IIncrementalGenerator
 
         var source = GeneratedSourceBuilder.Build(namedTypes, contractsAndImplementors, conventionServiceBindings, conventionSelfBindings);
         context.AddSource("GeneratedTypeDiscoveryProvider.g.cs", source);
+    }
+
+    static bool IsBuildTimeOnlyAssembly(Compilation compilation, IAssemblySymbol assembly)
+    {
+        // NuGet places non-runtime assets under reserved folders: tasks/ for MSBuild tasks
+        // and analyzers/ for Roslyn analyzers. Neither is copied to the consuming project's
+        // output, so emitting typeof() for their types fails to load at runtime.
+        var path = (compilation.GetMetadataReference(assembly) as PortableExecutableReference)?.FilePath;
+        if (path is not null)
+        {
+            var normalized = path.Replace('\\', '/');
+            if (normalized.Contains("/tasks/") || normalized.Contains("/analyzers/"))
+            {
+                return true;
+            }
+        }
+
+        // Defense-in-depth for in-tree analyzer projects that have not been NuGet-packaged
+        // and therefore are loaded from bin/ rather than from analyzers/.
+        return assembly.Modules.Any(static m => m.ReferencedAssemblies.Any(
+            static r => r.Name.StartsWith("Microsoft.CodeAnalysis", StringComparison.Ordinal)));
     }
 }


### PR DESCRIPTION
## Fixed
- Type discovery no longer emits `typeof()` references for assemblies loaded from a NuGet package's `tasks/` (MSBuild task helpers such as `Cratis.Arc.ProxyGenerator.Build`) or `analyzers/` folder. Previously, generated `SelfBindings` would throw `FileNotFoundException` at runtime because those DLLs are not copied to the consuming project's output.