### PR TITLE
Fix diagnostics DI ambiguity for keyed and unkeyed registrations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
         "netstandard",
         "Newtonsoft",
         "runtimepack",
+        "unkeyed",
         "Xunit"
     ],
     "dotnet.defaultSolution": "Fundamentals.slnx"

--- a/Source/DotNET/Fundamentals.Specs/DependencyInjection/for_DiagnosticsServiceCollectionExtensions/when_adding_named_activity_source_with_unkeyed_activity_source_registered.cs
+++ b/Source/DotNET/Fundamentals.Specs/DependencyInjection/for_DiagnosticsServiceCollectionExtensions/when_adding_named_activity_source_with_unkeyed_activity_source_registered.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using DiagnosticsActivitySource = System.Diagnostics.ActivitySource;
+
+namespace Cratis.DependencyInjection.for_DiagnosticsServiceCollectionExtensions;
+
+public class when_adding_named_activity_source_with_unkeyed_activity_source_registered : Specification
+{
+    const string sourceName = "my-source";
+    IServiceProvider _serviceProvider;
+    Traces.IActivitySource<when_adding_named_activity_source_with_unkeyed_activity_source_registered> _typedSource;
+    DiagnosticsActivitySource _source;
+
+    void Establish()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(new DiagnosticsActivitySource("unkeyed"));
+        services.AddNamedActivitySource(sourceName);
+        _serviceProvider = services.BuildServiceProvider();
+    }
+
+    void Because()
+    {
+        _typedSource = _serviceProvider.GetRequiredKeyedService<Traces.IActivitySource<when_adding_named_activity_source_with_unkeyed_activity_source_registered>>(sourceName);
+        _source = _serviceProvider.GetRequiredKeyedService<DiagnosticsActivitySource>(sourceName);
+    }
+
+    [Fact] void should_resolve_typed_activity_source() => _typedSource.ShouldNotBeNull();
+    [Fact] void should_use_the_named_activity_source() => _typedSource.ActualSource.ShouldEqual(_source);
+    [Fact] void should_have_the_correct_name() => _typedSource.ActualSource.Name.ShouldEqual(sourceName);
+}

--- a/Source/DotNET/Fundamentals.Specs/DependencyInjection/for_DiagnosticsServiceCollectionExtensions/when_adding_named_meter_with_unkeyed_meter_registered.cs
+++ b/Source/DotNET/Fundamentals.Specs/DependencyInjection/for_DiagnosticsServiceCollectionExtensions/when_adding_named_meter_with_unkeyed_meter_registered.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.DependencyInjection.for_DiagnosticsServiceCollectionExtensions;
+
+public class when_adding_named_meter_with_unkeyed_meter_registered : Specification
+{
+    const string meterName = "my-meter";
+    IServiceProvider _serviceProvider;
+    Metrics.IMeter<when_adding_named_meter_with_unkeyed_meter_registered> _typedMeter;
+    Meter _meter;
+
+    void Establish()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(new Meter("unkeyed"));
+        services.AddNamedMeter(meterName);
+        _serviceProvider = services.BuildServiceProvider();
+    }
+
+    void Because()
+    {
+        _typedMeter = _serviceProvider.GetRequiredKeyedService<Metrics.IMeter<when_adding_named_meter_with_unkeyed_meter_registered>>(meterName);
+        _meter = _serviceProvider.GetRequiredKeyedService<Meter>(meterName);
+    }
+
+    [Fact] void should_resolve_typed_meter() => _typedMeter.ShouldNotBeNull();
+    [Fact] void should_use_the_named_meter() => _typedMeter.ActualMeter.ShouldEqual(_meter);
+    [Fact] void should_have_the_correct_name() => _typedMeter.ActualMeter.Name.ShouldEqual(meterName);
+}

--- a/Source/DotNET/Fundamentals.Specs/DependencyInjection/for_ServiceCollectionExtensions/when_adding_self_bindings_with_unkeyed_activity_source_registered.cs
+++ b/Source/DotNET/Fundamentals.Specs/DependencyInjection/for_ServiceCollectionExtensions/when_adding_self_bindings_with_unkeyed_activity_source_registered.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using Cratis.DependencyInjection;
+using Cratis.Traces;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.DependencyInjection.for_ServiceCollectionExtensions;
+
+public class when_adding_self_bindings_with_unkeyed_activity_source_registered : Specification
+{
+    ServiceProvider _serviceProvider;
+    IActivitySource<when_adding_self_bindings_with_unkeyed_activity_source_registered> _result;
+
+    void Establish()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(new ActivitySource("unkeyed"));
+        services.AddSelfBindings();
+        _serviceProvider = services.BuildServiceProvider();
+    }
+
+    void Because() => _result = _serviceProvider.GetRequiredService<IActivitySource<when_adding_self_bindings_with_unkeyed_activity_source_registered>>();
+
+    void Destroy() => _serviceProvider.Dispose();
+
+    [Fact] void should_resolve_the_activity_source() => _result.ShouldNotBeNull();
+    [Fact] void should_use_the_type_name_for_the_source() => _result.ActualSource.Name.ShouldEqual(typeof(when_adding_self_bindings_with_unkeyed_activity_source_registered).FullName);
+}

--- a/Source/DotNET/Fundamentals.Specs/DependencyInjection/for_ServiceCollectionExtensions/when_adding_self_bindings_with_unkeyed_meter_registered.cs
+++ b/Source/DotNET/Fundamentals.Specs/DependencyInjection/for_ServiceCollectionExtensions/when_adding_self_bindings_with_unkeyed_meter_registered.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.Metrics;
+using Cratis.DependencyInjection;
+using Cratis.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.DependencyInjection.for_ServiceCollectionExtensions;
+
+public class when_adding_self_bindings_with_unkeyed_meter_registered : Specification
+{
+    ServiceProvider _serviceProvider;
+    IMeter<when_adding_self_bindings_with_unkeyed_meter_registered> _result;
+
+    void Establish()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(new Meter("unkeyed"));
+        services.AddSelfBindings();
+        _serviceProvider = services.BuildServiceProvider();
+    }
+
+    void Because() => _result = _serviceProvider.GetRequiredService<IMeter<when_adding_self_bindings_with_unkeyed_meter_registered>>();
+
+    void Destroy() => _serviceProvider.Dispose();
+
+    [Fact] void should_resolve_the_meter() => _result.ShouldNotBeNull();
+    [Fact] void should_use_the_type_name_for_the_meter() => _result.ActualMeter.Name.ShouldEqual(typeof(when_adding_self_bindings_with_unkeyed_meter_registered).FullName);
+}

--- a/Source/DotNET/Fundamentals.Specs/Types/for_Types/when_using_generated_type_discovery_for_current_assembly.cs
+++ b/Source/DotNET/Fundamentals.Specs/Types/for_Types/when_using_generated_type_discovery_for_current_assembly.cs
@@ -10,14 +10,14 @@ public class when_using_generated_type_discovery_for_current_assembly : Specific
     void Because() => result =
     [
         ..new Types(GeneratedTypeDiscoveryRegistry.Providers)
-            .FindMultiple<global::Cratis.Types.for_ContractToImplementorsMap.IInterface>()
+            .FindMultiple<for_ContractToImplementorsMap.IInterface>()
     ];
 
     [Fact] void should_find_the_known_implementations() => result.ShouldContainOnly(
     [
-        typeof(global::Cratis.Types.for_ContractToImplementorsMap.ImplementationOfInterface),
-        typeof(global::Cratis.Types.for_ContractToImplementorsMap.SecondImplementationOfInterface),
-        typeof(global::Cratis.Types.for_ContractToImplementorsMap.ImplementationOfAbstractClassWithInterface),
-        typeof(global::Cratis.Types.for_ContractToImplementorsMap.SecondImplementationOfAbstractClassWithInterface)
+        typeof(for_ContractToImplementorsMap.ImplementationOfInterface),
+        typeof(for_ContractToImplementorsMap.SecondImplementationOfInterface),
+        typeof(for_ContractToImplementorsMap.ImplementationOfAbstractClassWithInterface),
+        typeof(for_ContractToImplementorsMap.SecondImplementationOfAbstractClassWithInterface)
     ]);
 }

--- a/Source/DotNET/Fundamentals/DependencyInjection/DiagnosticsServiceCollectionExtensions.cs
+++ b/Source/DotNET/Fundamentals/DependencyInjection/DiagnosticsServiceCollectionExtensions.cs
@@ -25,7 +25,7 @@ public static class DiagnosticsServiceCollectionExtensions
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
 
         services.TryAddKeyedSingleton(typeof(Meter), name, static (_, key) => new Meter((string)key!));
-        services.TryAddKeyedSingleton(typeof(IMeter<>), name, typeof(Meter<>));
+        services.TryAddKeyedSingleton(typeof(IMeter<>), name, typeof(KeyedMeter<>));
 
         return services;
     }
@@ -41,7 +41,7 @@ public static class DiagnosticsServiceCollectionExtensions
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
 
         services.TryAddKeyedSingleton(typeof(DiagnosticsActivitySource), name, static (_, key) => new DiagnosticsActivitySource((string)key!));
-        services.TryAddKeyedSingleton(typeof(IActivitySource<>), name, typeof(ActivitySource<>));
+        services.TryAddKeyedSingleton(typeof(IActivitySource<>), name, typeof(KeyedActivitySource<>));
 
         return services;
     }

--- a/Source/DotNET/Fundamentals/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Source/DotNET/Fundamentals/DependencyInjection/ServiceCollectionExtensions.cs
@@ -50,8 +50,8 @@ public static class ServiceCollectionExtensions
 
     static void AddDiagnosticsInstrumentation(IServiceCollection services)
     {
-        services.TryAddSingleton(typeof(IMeter<>), typeof(Meter<>));
-        services.TryAddSingleton(typeof(IActivitySource<>), typeof(ActivitySource<>));
+        services.TryAddSingleton(typeof(IMeter<>), typeof(UnkeyedMeter<>));
+        services.TryAddSingleton(typeof(IActivitySource<>), typeof(UnkeyedActivitySource<>));
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Generated convention metadata drives registration and constructors are preserved by generated usage in AOT scenarios.")]

--- a/Source/DotNET/Fundamentals/Metrics/KeyedMeter.cs
+++ b/Source/DotNET/Fundamentals/Metrics/KeyedMeter.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Metrics;
+
+/// <summary>
+/// Represents a keyed typed <see cref="Meter"/>.
+/// </summary>
+/// <typeparam name="T">Type the meter is for.</typeparam>
+/// <param name="serviceProvider">The <see cref="IServiceProvider"/> used for resolving keyed services.</param>
+/// <param name="key">The key used when resolving the service.</param>
+public class KeyedMeter<T>(IServiceProvider serviceProvider, [ServiceKey] string? key = null) : IMeter<T>
+{
+    /// <inheritdoc/>
+    public Meter ActualMeter { get; } = key is null
+        ? new(typeof(T).FullName ?? typeof(T).Name)
+        : serviceProvider.GetRequiredKeyedService<Meter>(key);
+}

--- a/Source/DotNET/Fundamentals/Metrics/UnkeyedMeter.cs
+++ b/Source/DotNET/Fundamentals/Metrics/UnkeyedMeter.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.Metrics;
+
+namespace Cratis.Metrics;
+
+/// <summary>
+/// Represents an unkeyed typed <see cref="Meter"/>.
+/// </summary>
+/// <typeparam name="T">Type the meter is for.</typeparam>
+public class UnkeyedMeter<T> : IMeter<T>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UnkeyedMeter{T}"/> class.
+    /// </summary>
+    public UnkeyedMeter()
+    {
+        ActualMeter = new(typeof(T).FullName ?? typeof(T).Name);
+    }
+
+    /// <inheritdoc/>
+    public Meter ActualMeter { get; }
+}

--- a/Source/DotNET/Fundamentals/Traces/KeyedActivitySource.cs
+++ b/Source/DotNET/Fundamentals/Traces/KeyedActivitySource.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.DependencyInjection;
+using DiagnosticsActivitySource = System.Diagnostics.ActivitySource;
+
+namespace Cratis.Traces;
+
+/// <summary>
+/// Represents a keyed typed <see cref="DiagnosticsActivitySource"/>.
+/// </summary>
+/// <typeparam name="T">Type the activity source is for.</typeparam>
+/// <param name="serviceProvider">The <see cref="IServiceProvider"/> used for resolving keyed services.</param>
+/// <param name="key">The key used when resolving the service.</param>
+public class KeyedActivitySource<T>(IServiceProvider serviceProvider, [ServiceKey] string? key = null) : IActivitySource<T>
+{
+    /// <inheritdoc/>
+    public DiagnosticsActivitySource ActualSource { get; } = key is null
+        ? new(typeof(T).FullName ?? typeof(T).Name)
+        : serviceProvider.GetRequiredKeyedService<DiagnosticsActivitySource>(key);
+}

--- a/Source/DotNET/Fundamentals/Traces/UnkeyedActivitySource.cs
+++ b/Source/DotNET/Fundamentals/Traces/UnkeyedActivitySource.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DiagnosticsActivitySource = System.Diagnostics.ActivitySource;
+
+namespace Cratis.Traces;
+
+/// <summary>
+/// Represents an unkeyed typed <see cref="DiagnosticsActivitySource"/>.
+/// </summary>
+/// <typeparam name="T">Type the activity source is for.</typeparam>
+public class UnkeyedActivitySource<T> : IActivitySource<T>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UnkeyedActivitySource{T}"/> class.
+    /// </summary>
+    public UnkeyedActivitySource()
+    {
+        ActualSource = new(typeof(T).FullName ?? typeof(T).Name);
+    }
+
+    /// <inheritdoc/>
+    public DiagnosticsActivitySource ActualSource { get; }
+}

--- a/Source/DotNET/Fundamentals/Types/GeneratedTypeDiscoveryRegistry.cs
+++ b/Source/DotNET/Fundamentals/Types/GeneratedTypeDiscoveryRegistry.cs
@@ -9,7 +9,7 @@ namespace Cratis.Types;
 public static class GeneratedTypeDiscoveryRegistry
 {
 #if NET9_0_OR_GREATER
-    static readonly System.Threading.Lock _gate = new();
+    static readonly Lock _gate = new();
 #else
     static readonly object _gate = new();
 #endif

--- a/Source/DotNET/Metrics.Roslyn.Specs/CompilationFactory.cs
+++ b/Source/DotNET/Metrics.Roslyn.Specs/CompilationFactory.cs
@@ -15,7 +15,7 @@ static class CompilationFactory
         Assembly.Load("System.Runtime"),
         Assembly.Load("netstandard"),
         typeof(System.Diagnostics.ActivitySource).Assembly,
-        typeof(Cratis.Traces.SpanAttribute).Assembly,
+        typeof(Traces.SpanAttribute).Assembly,
     ];
 
     public static CSharpCompilation CreateCompilation(string source, params Assembly[] additionalAssemblies)

--- a/Source/DotNET/Metrics.Roslyn.Specs/for_ActivityScopeUsingAnalyzer/when_not_using_a_using_declaration.cs
+++ b/Source/DotNET/Metrics.Roslyn.Specs/for_ActivityScopeUsingAnalyzer/when_not_using_a_using_declaration.cs
@@ -9,7 +9,7 @@ namespace Cratis.Metrics.Roslyn.Specs.for_ActivityScopeUsingAnalyzer;
 
 public class when_not_using_a_using_declaration : Specification
 {
-    ImmutableArray<Microsoft.CodeAnalysis.Diagnostic> _diagnostics;
+    ImmutableArray<Diagnostic> _diagnostics;
 
     void Because() => _diagnostics = AnalyzerRunner.Run(
         @"

--- a/Source/DotNET/Metrics.Roslyn.Specs/for_ActivityScopeUsingAnalyzer/when_using_a_using_declaration.cs
+++ b/Source/DotNET/Metrics.Roslyn.Specs/for_ActivityScopeUsingAnalyzer/when_using_a_using_declaration.cs
@@ -9,7 +9,7 @@ namespace Cratis.Metrics.Roslyn.Specs.for_ActivityScopeUsingAnalyzer;
 
 public class when_using_a_using_declaration : Specification
 {
-    ImmutableArray<Microsoft.CodeAnalysis.Diagnostic> _diagnostics;
+    ImmutableArray<Diagnostic> _diagnostics;
 
     void Because() => _diagnostics = AnalyzerRunner.Run(
         @"


### PR DESCRIPTION
## Changed
- Route named and default diagnostics registrations through dedicated keyed and unkeyed meter/activity source implementations to avoid constructor-selection ambiguity during DI activation.
- Align related specs and analyzer test sources with concise type references and update local dictionary entries for new diagnostics terminology.

## Fixed
- Prevent failures resolving `IActivitySource<T>` and `IMeter<T>` when an unkeyed framework `ActivitySource` or `Meter` is present in the service collection.
- Add regression specs covering named and self-binding diagnostics resolution with unkeyed framework diagnostics registrations.