### PR TITLE
Fix PointJsonConverter to accept C#-serialized { longitude, latitude } format

### DIFF
--- a/Documentation/csharp/geospatial/index.md
+++ b/Documentation/csharp/geospatial/index.md
@@ -1,6 +1,6 @@
 # Geospatial Types
 
-Cratis provides strongly-typed geospatial types for working with geographic coordinates following the [GeoJSON specification](https://www.mongodb.com/docs/manual/reference/geojson/).
+Cratis provides strongly-typed geospatial types for working with geographic coordinates following the [GeoJSON specification](https://geojson.org).
 
 ## Types
 

--- a/Documentation/csharp/geospatial/understanding.md
+++ b/Documentation/csharp/geospatial/understanding.md
@@ -33,7 +33,7 @@ A Polygon ring must have at least 4 points, with the first and last points ident
 
 ## JSON Serialization
 
-All types serialize to [GeoJSON](https://www.mongodb.com/docs/manual/reference/geojson/) format — a standard adopted by geographic databases and mapping services. This ensures your data integrates seamlessly with external tools and services.
+All types serialize to [GeoJSON](https://geojson.org) format — a standard adopted by geographic databases and mapping services. This ensures your data integrates seamlessly with external tools and services.
 
 When you send geospatial types to a database or across the network, they automatically convert to GeoJSON. The same conversion happens in reverse when deserializing.
 

--- a/Source/JavaScript/json/PointJsonConverter.ts
+++ b/Source/JavaScript/json/PointJsonConverter.ts
@@ -21,10 +21,13 @@ export class PointJsonConverter extends JsonConverter<Point> {
         if (value === null || value === undefined) {
             throw new Error('Cannot deserialize null or undefined to Point');
         }
-        if (value.type !== 'Point' || !value.coordinates || value.coordinates.length !== 2) {
-            throw new Error('Cannot deserialize Point: invalid GeoJSON format');
+        if (value.type === 'Point' && value.coordinates && value.coordinates.length === 2) {
+            return new Point(value.coordinates[0], value.coordinates[1]);
         }
-        return new Point(value.coordinates[0], value.coordinates[1]);
+        if (typeof value.longitude === 'number' && typeof value.latitude === 'number') {
+            return new Point(value.longitude, value.latitude);
+        }
+        throw new Error('Cannot deserialize Point: expected GeoJSON format { type, coordinates } or { longitude, latitude }');
     }
 
     /** @inheritdoc */


### PR DESCRIPTION
## Fixed
- `PointJsonConverter` now accepts both GeoJSON format `{ type, coordinates }` and the C# default-serialized format `{ longitude, latitude }`, fixing deserialization errors in frontends consuming Arc backends without the geospatial converters registered