### PR TITLE
Export reflection metadata polyfill as a subpath

### DIFF
--- a/Source/JavaScript/package.json
+++ b/Source/JavaScript/package.json
@@ -34,6 +34,11 @@
             "types": "./dist/esm/json/index.d.ts",
             "import": "./dist/esm/json/index.js",
             "require": "./dist/cjs/json/index.js"
+        },
+        "./reflection": {
+            "types": "./dist/esm/reflection.d.ts",
+            "import": "./dist/esm/reflection.js",
+            "require": "./dist/cjs/reflection.js"
         }
     },
     "scripts": {

--- a/Source/JavaScript/reflection.ts
+++ b/Source/JavaScript/reflection.ts
@@ -25,6 +25,7 @@ declare global {
         function getMetadataKeys(target: any, propertyKey?: string | symbol): (string | symbol)[];
         function getOwnMetadataKeys(target: any, propertyKey?: string | symbol): (string | symbol)[];
         function deleteMetadata(metadataKey: string | symbol, target: any, propertyKey?: string | symbol): boolean;
+        function metadata(metadataKey: string | symbol, metadataValue: any): (target: any, propertyKey?: string | symbol) => void;
     }
 }
 
@@ -123,6 +124,15 @@ if (typeof Reflect.defineMetadata !== 'function' || typeof Reflect.getOwnMetadat
     Reflect.deleteMetadata = function (metadataKey: string | symbol, target: any, propertyKey?: string | symbol): boolean {
         const store = getMetadataStoreIfExists(target, propertyKey);
         return store ? store.delete(metadataKey) : false;
+    };
+
+    // Decorator factory used by TypeScript's emitDecoratorMetadata output (the tslib
+    // __metadata helper). Without this, 'design:type'/'design:paramtypes'/'design:returntype'
+    // metadata is never recorded, which breaks constructor parameter type reflection.
+    Reflect.metadata = function (metadataKey: string | symbol, metadataValue: any): (target: any, propertyKey?: string | symbol) => void {
+        return function (target: any, propertyKey?: string | symbol): void {
+            Reflect.defineMetadata(metadataKey, metadataValue, target, propertyKey);
+        };
     };
 }
 


### PR DESCRIPTION
## Added

- `@cratis/fundamentals/reflection` subpath export, allowing the Reflect metadata polyfill to be side-effect imported directly (#1079)

## Fixed

- `Reflect.metadata` is now provided by the metadata polyfill, so TypeScript's `emitDecoratorMetadata` output records `design:paramtypes` and constructor parameter type reflection works (e.g. with tsyringe) (#1079)