### PR TITLE
Include inherited fields when deserializing a derived type

### DIFF
--- a/Source/JavaScript/Fields.ts
+++ b/Source/JavaScript/Fields.ts
@@ -19,14 +19,29 @@ export class Fields {
     }
 
     static getFieldsForType(target: Constructor): Field[] {
-        const fields: Field[] = [];
-        if (Reflect.hasOwnMetadata('fields', target)) {
-            const fieldsMap = Reflect.getOwnMetadata('fields', target) as Map<string, Field>;
-            for (const field of fieldsMap.entries()) {
-                fields.push(field[1]);
+        // Fields are stored as own-metadata per type, so a derived type only carries the fields it
+        // declares itself. Walk the prototype (inheritance) chain and merge every ancestor's fields so
+        // that deserializing a derived type also populates the fields inherited from its base types.
+        // Process from the base type down to the target so a derived field overrides a base field of the
+        // same name.
+        const chain: Constructor[] = [];
+        let current: Constructor | undefined = target;
+        while (current && current !== Function.prototype && current !== Object) {
+            chain.push(current);
+            current = Object.getPrototypeOf(current) as Constructor | undefined;
+        }
+
+        const fieldsByName = new Map<string, Field>();
+        for (let index = chain.length - 1; index >= 0; index--) {
+            const type = chain[index];
+            if (Reflect.hasOwnMetadata('fields', type)) {
+                const fieldsMap = Reflect.getOwnMetadata('fields', type) as Map<string, Field>;
+                for (const [name, field] of fieldsMap.entries()) {
+                    fieldsByName.set(name, field);
+                }
             }
         }
 
-        return fields;
+        return [...fieldsByName.values()];
     }
 }

--- a/Source/JavaScript/for_Fields/when_getting_fields_for_a_derived_type_that_overrides_a_base_field.ts
+++ b/Source/JavaScript/for_Fields/when_getting_fields_for_a_derived_type_that_overrides_a_base_field.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Fields } from '../Fields';
+
+class OverrideBase {
+}
+
+class OverrideDerived extends OverrideBase {
+}
+
+describe('when getting fields for a derived type that overrides a base field', () => {
+    Fields.addFieldToType(OverrideBase, 'value', String, false, [], []);
+    Fields.addFieldToType(OverrideDerived, 'value', Number, false, [], []);
+
+    const fields = Fields.getFieldsForType(OverrideDerived);
+
+    it('should keep a single entry for the overridden field', () => fields.filter(_ => _.name === 'value').length.should.equal(1));
+    it('should use the derived type field definition', () => fields.find(_ => _.name === 'value')!.type.should.equal(Number));
+});

--- a/Source/JavaScript/for_Fields/when_getting_fields_for_derived_type.ts
+++ b/Source/JavaScript/for_Fields/when_getting_fields_for_derived_type.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Fields } from '../Fields';
+
+class BaseType {
+}
+
+class MiddleType extends BaseType {
+}
+
+class DerivedType extends MiddleType {
+}
+
+describe('when getting fields for derived type', () => {
+    Fields.addFieldToType(BaseType, 'baseField', String, false, [], []);
+    Fields.addFieldToType(MiddleType, 'middleField', Number, false, [], []);
+    Fields.addFieldToType(DerivedType, 'derivedField', Boolean, false, [], []);
+
+    const fields = Fields.getFieldsForType(DerivedType);
+    const names = fields.map(_ => _.name);
+
+    it('should include the field declared on the derived type', () => names.should.contain('derivedField'));
+    it('should include the field inherited from the middle type', () => names.should.contain('middleField'));
+    it('should include the field inherited from the base type', () => names.should.contain('baseField'));
+    it('should include all three fields', () => fields.length.should.equal(3));
+});


### PR DESCRIPTION
## Fixed

- `JsonSerializer` now populates fields inherited from base types when deserializing a derived (polymorphic) type. Previously `getFieldsForType` only read a type's own field metadata, so a resolved derived type came back with its inherited properties unset.