### PR TITLE
Preserve the derived-type discriminator across (de)serialization

### DIFF
--- a/Source/JavaScript/JsonSerializer.ts
+++ b/Source/JavaScript/JsonSerializer.ts
@@ -240,11 +240,18 @@ const convertTypesOnInstance = (instance: any) => {
     const properties = Object.getOwnPropertyNames(instance);
     const converted: any = {};
 
-    const derivedTypeId = DerivedType.get(instance.constructor);
+    // Emit the polymorphic type discriminator, preferring the registered type for the instance's
+    // constructor and falling back to a discriminator preserved on the instance itself (e.g. a value
+    // that was deserialized before its concrete type could be resolved). This keeps '_derivedTypeId'
+    // flowing through serialization transparently — the caller never has to manage it — and is the
+    // mirror of preserving it on deserialization.
+    const derivedTypeId = DerivedType.get(instance.constructor) ?? instance[JsonSerializer.DerivedTypeIdProperty];
     if (derivedTypeId) {
         converted[JsonSerializer.DerivedTypeIdProperty] = derivedTypeId;
     }
     properties.forEach(property => {
+        // The discriminator is handled above as a meta-property; never treat it as a data field.
+        if (property === JsonSerializer.DerivedTypeIdProperty) return;
         let value = instance[property];
         if (value !== undefined) {
             if (Array.isArray(value)) {
@@ -327,6 +334,16 @@ export class JsonSerializer {
             }
 
             deserialized[field.name] = value;
+        }
+
+        // Preserve the polymorphic type discriminator so it is never lost across (de)serialization
+        // layers. '_derivedTypeId' is not a declared field, so it is otherwise dropped here — and a
+        // derived value whose concrete type could not be resolved (e.g. its type was not yet
+        // registered) would then have no discriminator left to re-resolve or round-trip with, and
+        // would serialize back with no type information at all.
+        const derivedTypeId = instance[JsonSerializer.DerivedTypeIdProperty];
+        if (derivedTypeId !== undefined && derivedTypeId !== null) {
+            (deserialized as Record<string, unknown>)[JsonSerializer.DerivedTypeIdProperty] = derivedTypeId;
         }
 
         if ((targetType as Constructor) == Object) {

--- a/Source/JavaScript/for_JsonSerializer/when_deserializing_a_field_whose_derived_type_cannot_be_resolved.ts
+++ b/Source/JavaScript/for_JsonSerializer/when_deserializing_a_field_whose_derived_type_cannot_be_resolved.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { JsonSerializer } from '../JsonSerializer';
+import { field } from '../fieldDecorator';
+
+class UnresolvableBase {
+    @field(String)
+    name!: string;
+}
+
+class ContainerWithUnresolvableBase {
+    @field(UnresolvableBase)
+    item!: UnresolvableBase;
+}
+
+// The discriminator references a derived type that is not registered, so it cannot be resolved to a
+// concrete type during deserialization — the value falls back to the declared base type.
+const json = JSON.stringify({
+    item: {
+        name: 'kept',
+        [JsonSerializer.DerivedTypeIdProperty]: 'unregistered-type-id'
+    }
+});
+
+describe('when deserializing a field whose derived type cannot be resolved', () => {
+    const result = JsonSerializer.deserialize(ContainerWithUnresolvableBase, json);
+    const reserialized = JSON.parse(JsonSerializer.serialize(result));
+
+    it('should fall back to the declared base type', () => result.item.constructor.should.equal(UnresolvableBase));
+    it('should keep the declared field value', () => result.item.name.should.equal('kept'));
+    it('should preserve the discriminator on the deserialized instance', () => (result.item as Record<string, unknown>)[JsonSerializer.DerivedTypeIdProperty].should.equal('unregistered-type-id'));
+    it('should round-trip the discriminator back out on serialization', () => reserialized.item[JsonSerializer.DerivedTypeIdProperty].should.equal('unregistered-type-id'));
+});


### PR DESCRIPTION
## Fixed

- `JsonSerializer` now preserves the `_derivedTypeId` discriminator through both deserialization and serialization. Previously, deserializing a polymorphic value whose concrete type could not be resolved (e.g. its derived type was not yet registered) dropped the discriminator, so the value could never be re-resolved or round-tripped and serialized back with no type information. The discriminator now flows transparently in both directions.