### PR TITLE
Fix build failure from MA0206 unnecessary type declaration braces

### DIFF
--- a/Source/DotNET/Fundamentals.Specs/Reflection/for_TypeConstructorExtensions/TypeWithoutDefaultConstructor.cs
+++ b/Source/DotNET/Fundamentals.Specs/Reflection/for_TypeConstructorExtensions/TypeWithoutDefaultConstructor.cs
@@ -3,6 +3,4 @@
 
 namespace Cratis.Reflection.for_TypeExtensions;
 
-public class TypeWithoutDefaultConstructor(string something)
-{
-}
+public class TypeWithoutDefaultConstructor(string something);

--- a/Source/DotNET/Fundamentals/Collections/ItemAlreadyAddedToBinaryTree.cs
+++ b/Source/DotNET/Fundamentals/Collections/ItemAlreadyAddedToBinaryTree.cs
@@ -10,6 +10,4 @@ namespace Cratis.Collections;
 /// Initializes a new instance of the <see cref="ItemAlreadyAddedToBinaryTree"/> class.
 /// </remarks>
 /// <param name="item">Element already added.</param>
-public class ItemAlreadyAddedToBinaryTree(object item) : Exception($"Item '{item}' has already been added to the tree.")
-{
-}
+public class ItemAlreadyAddedToBinaryTree(object item) : Exception($"Item '{item}' has already been added to the tree.");

--- a/Source/DotNET/Fundamentals/Concepts/TypeIsNotAConcept.cs
+++ b/Source/DotNET/Fundamentals/Concepts/TypeIsNotAConcept.cs
@@ -10,6 +10,4 @@ namespace Cratis.Concepts;
 /// Initializes a new instance of the <see cref="TypeIsNotAConcept"/> class.
 /// </remarks>
 /// <param name="type"><see cref="Type"/> that is not a concept.</param>
-public class TypeIsNotAConcept(Type type) : Exception($"Type '{type.AssemblyQualifiedName}' is not a concept - implement ConceptAs<> for it to be one.")
-{
-}
+public class TypeIsNotAConcept(Type type) : Exception($"Type '{type.AssemblyQualifiedName}' is not a concept - implement ConceptAs<> for it to be one.");

--- a/Source/DotNET/Fundamentals/Serialization/AmbiguousDerivedTypeIdentifiers.cs
+++ b/Source/DotNET/Fundamentals/Serialization/AmbiguousDerivedTypeIdentifiers.cs
@@ -10,6 +10,4 @@ namespace Cratis.Serialization;
 /// Initializes a new instance of the <see cref="AmbiguousDerivedTypeIdentifiers"/> class.
 /// </remarks>
 /// <param name="types">Types that have the same identifier.</param>
-public class AmbiguousDerivedTypeIdentifiers(IEnumerable<Type> types) : Exception($"The types '{string.Join(", ", types.Select(_ => _.FullName))}' have the same derived type identifier.")
-{
-}
+public class AmbiguousDerivedTypeIdentifiers(IEnumerable<Type> types) : Exception($"The types '{string.Join(", ", types.Select(_ => _.FullName))}' have the same derived type identifier.");

--- a/Source/DotNET/Fundamentals/Serialization/AmbiguousTargetTypeForDerivedType.cs
+++ b/Source/DotNET/Fundamentals/Serialization/AmbiguousTargetTypeForDerivedType.cs
@@ -11,6 +11,4 @@ namespace Cratis.Serialization;
 /// </remarks>
 /// <param name="type">Type that has multiple interfaces implemented.</param>
 public class AmbiguousTargetTypeForDerivedType(Type type) :
-    Exception($"Type '{type.FullName}' implements interfaces without specifying which interface it is a derived type of, there can be only one (the Highlander principle). The DerivedTypeAttribute has a parameter for specifying the interface.")
-{
-}
+    Exception($"Type '{type.FullName}' implements interfaces without specifying which interface it is a derived type of, there can be only one (the Highlander principle). The DerivedTypeAttribute has a parameter for specifying the interface.");

--- a/Source/DotNET/Fundamentals/Serialization/MissingDerivedTypeForTargetType.cs
+++ b/Source/DotNET/Fundamentals/Serialization/MissingDerivedTypeForTargetType.cs
@@ -12,6 +12,4 @@ namespace Cratis.Serialization;
 /// <param name="targetType">Type of target type.</param>
 /// <param name="derivedTypeId">The unique identifier of the expected derived type.</param>
 public class MissingDerivedTypeForTargetType(Type targetType, DerivedTypeId derivedTypeId) :
-    Exception($"Missing derived type with identifier '{derivedTypeId}' for target type '{targetType}'.")
-{
-}
+    Exception($"Missing derived type with identifier '{derivedTypeId}' for target type '{targetType}'.");

--- a/Source/DotNET/Fundamentals/Serialization/MissingTargetTypeForDerivedType.cs
+++ b/Source/DotNET/Fundamentals/Serialization/MissingTargetTypeForDerivedType.cs
@@ -11,6 +11,4 @@ namespace Cratis.Serialization;
 /// </remarks>
 /// <param name="type">Type that is missing interfaces.</param>
 public class MissingTargetTypeForDerivedType(Type type) :
-    Exception($"Type '{type.FullName}' does not implement any interface it is a derived type of. Remember there can be only one (the Highlander principle) it represents as a derived type. The DerivedTypeAttribute has a parameter for specifying this interface if you need multiple")
-{
-}
+    Exception($"Type '{type.FullName}' does not implement any interface it is a derived type of. Remember there can be only one (the Highlander principle) it represents as a derived type. The DerivedTypeAttribute has a parameter for specifying this interface if you need multiple");

--- a/Source/DotNET/Fundamentals/Serialization/TargetTypeMismatchForDerivedType.cs
+++ b/Source/DotNET/Fundamentals/Serialization/TargetTypeMismatchForDerivedType.cs
@@ -11,6 +11,4 @@ namespace Cratis.Serialization;
 /// </remarks>
 /// <param name="type">Type that is missing interfaces.</param>
 public class TargetTypeMismatchForDerivedType(Type type) :
-    Exception($"The specified target type used for '{type.FullName}' does not match any of the interfaces.")
-{
-}
+    Exception($"The specified target type used for '{type.FullName}' does not match any of the interfaces.");

--- a/Source/DotNET/Fundamentals/Types/MultipleTypesFound.cs
+++ b/Source/DotNET/Fundamentals/Types/MultipleTypesFound.cs
@@ -12,6 +12,4 @@ namespace Cratis.Types;
 /// <param name="type">Type that multiple of it.</param>
 /// <param name="typesFound">The types that was found.</param>
 public class MultipleTypesFound(Type type, IEnumerable<Type> typesFound) :
-    ArgumentException($"More than one type found for '{type.FullName}' - types found : [{string.Join(',', typesFound.Select(_ => _.FullName))}]")
-{
-}
+    ArgumentException($"More than one type found for '{type.FullName}' - types found : [{string.Join(',', typesFound.Select(_ => _.FullName))}]");

--- a/Source/DotNET/Fundamentals/Types/UnableToResolveTypeByName.cs
+++ b/Source/DotNET/Fundamentals/Types/UnableToResolveTypeByName.cs
@@ -10,6 +10,4 @@ namespace Cratis.Types;
 /// Initializes a new instance of the <see cref="UnableToResolveTypeByName"/> class.
 /// </remarks>
 /// <param name="typeName">Name of the type that was not possible to resolve.</param>
-public class UnableToResolveTypeByName(string typeName) : ArgumentException($"Unable to resolve '{typeName}'.")
-{
-}
+public class UnableToResolveTypeByName(string typeName) : ArgumentException($"Unable to resolve '{typeName}'.");


### PR DESCRIPTION
## Fixed
- Fixed a build failure caused by the Meziantou.Analyzer MA0206 rule flagging unnecessary empty braces on exception types using primary constructors.