### PR TITLE
Make type discovery resilient to types that cannot be loaded

### DIFF
--- a/Source/DotNET/Fundamentals.Specs/Types/for_ContractToImplementorsMap/when_feeding_a_type_that_cannot_be_inspected.cs
+++ b/Source/DotNET/Fundamentals.Specs/Types/for_ContractToImplementorsMap/when_feeding_a_type_that_cannot_be_inspected.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+namespace Cratis.Types.for_ContractToImplementorsMap;
+
+public class when_feeding_a_type_that_cannot_be_inspected : given.an_empty_map
+{
+    Exception error;
+
+    void Because() => error = Catch.Exception(() => map.Feed(
+    [
+        typeof(ImplementationOfInterface),
+        new type_that_throws_on_inspection(),
+        typeof(SecondImplementationOfInterface)
+    ]));
+
+    [Fact] void should_not_fail() => error.ShouldBeNull();
+    [Fact] void should_still_map_the_loadable_implementations() =>
+        map.GetImplementorsFor(typeof(IInterface)).ShouldContainOnly(typeof(ImplementationOfInterface), typeof(SecondImplementationOfInterface));
+
+    /// <summary>
+    /// A type whose base/interface inspection throws <see cref="TypeLoadException"/>, simulating a
+    /// referenced assembly that resolves to a version no longer containing a referenced type.
+    /// </summary>
+    sealed class type_that_throws_on_inspection() : TypeDelegator(typeof(ImplementationOfInterface))
+    {
+        public override Type[] GetInterfaces() => throw new TypeLoadException("Simulated missing referenced type");
+    }
+}

--- a/Source/DotNET/Fundamentals/Types/ContractToImplementorsMap.cs
+++ b/Source/DotNET/Fundamentals/Types/ContractToImplementorsMap.cs
@@ -69,10 +69,20 @@ public class ContractToImplementorsMap : IContractToImplementorsMap
         var implementors = types.Where(IsImplementation);
         Parallel.ForEach(implementors, implementor =>
         {
-            foreach (var contract in implementor.AllBaseAndImplementingTypes())
+            try
             {
-                var implementingTypes = GetImplementingTypesFor(contract);
-                if (!implementingTypes.Contains(implementor)) implementingTypes.Add(implementor);
+                foreach (var contract in implementor.AllBaseAndImplementingTypes())
+                {
+                    var implementingTypes = GetImplementingTypesFor(contract);
+                    if (!implementingTypes.Contains(implementor)) implementingTypes.Add(implementor);
+                }
+            }
+            catch (TypeLoadException)
+            {
+                // Skip an implementor whose base or implemented types cannot be loaded — for example
+                // when a referenced assembly resolves to a version that no longer contains a type another
+                // assembly references. Type discovery is best-effort; a single unloadable type must not
+                // abort the whole scan, which previously crashed application startup.
             }
         });
     }
@@ -89,7 +99,17 @@ public class ContractToImplementorsMap : IContractToImplementorsMap
         }
     }
 
-    bool IsImplementation(Type type) => !type.IsInterface && !type.IsAbstract;
+    bool IsImplementation(Type type)
+    {
+        try
+        {
+            return !type.IsInterface && !type.IsAbstract;
+        }
+        catch (TypeLoadException)
+        {
+            return false;
+        }
+    }
 
     ConcurrentBag<Type> GetImplementingTypesFor(Type contract)
     {

--- a/Source/DotNET/Fundamentals/Types/ProjectReferencedAssemblies.cs
+++ b/Source/DotNET/Fundamentals/Types/ProjectReferencedAssemblies.cs
@@ -60,7 +60,17 @@ public class ProjectReferencedAssemblies : ICanProvideAssembliesForDiscovery
                 _assemblies.Add(entryAssembly);
             }
             _assemblies.AddRange(projectReferencedAssemblies);
-            DefinedTypes = [.. _assemblies.SelectMany(_ => _.DefinedTypes)];
+            DefinedTypes = [.. _assemblies.SelectMany(_ =>
+            {
+                try
+                {
+                    return _.DefinedTypes;
+                }
+                catch
+                {
+                    return [];
+                }
+            })];
 
             _initialized = true;
         }


### PR DESCRIPTION
# Summary

Makes assembly/type discovery resilient so a single type that cannot be loaded no longer crashes application startup.

## Fixed

- Type discovery (`ContractToImplementorsMap`) no longer aborts the whole scan — and the process — when inspecting a type whose base or interface types throw `TypeLoadException` (for example when a referenced assembly resolves to a version that no longer contains a referenced type). The unloadable type is skipped and the remaining types are still discovered.
- `ProjectReferencedAssemblies` now tolerates assemblies whose `DefinedTypes` fail to enumerate, matching the existing behavior of `PackageReferencedAssemblies`.
