### PR TITLE
Tolerate provider type enumeration that cannot be loaded

### DIFF
--- a/Source/DotNET/Fundamentals.Specs/Types/for_Types/when_a_provider_yields_a_type_that_cannot_be_loaded.cs
+++ b/Source/DotNET/Fundamentals.Specs/Types/for_Types/when_a_provider_yields_a_type_that_cannot_be_loaded.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+namespace Cratis.Types.for_Types;
+
+public class when_a_provider_yields_a_type_that_cannot_be_loaded : Specification
+{
+    Exception _error;
+    Type[] _implementors;
+
+    void Because() => _error = Catch.Exception(() =>
+        _implementors =
+        [
+            ..new Types([new provider_that_throws_while_enumerating(), new plain_assembly_provider()])
+                .FindMultiple<IPackageOnlyInterface>()
+        ]);
+
+    [Fact] void should_not_fail() => _error.ShouldBeNull();
+    [Fact] void should_still_discover_types_from_the_loadable_provider() => _implementors.ShouldContainOnly(typeof(PackageOnlyImplementation));
+
+    /// <summary>
+    /// A provider whose type enumeration throws <see cref="TypeLoadException"/> partway through, simulating a
+    /// referenced assembly that resolves to a version no longer containing a referenced type.
+    /// </summary>
+    class provider_that_throws_while_enumerating : ICanProvideAssembliesForDiscovery
+    {
+        public IEnumerable<Assembly> Assemblies => [typeof(provider_that_throws_while_enumerating).Assembly];
+
+        public IEnumerable<Type> DefinedTypes
+        {
+            get
+            {
+                yield return typeof(object);
+                throw new TypeLoadException("Simulated missing referenced type");
+            }
+        }
+
+        public void Initialize()
+        {
+        }
+    }
+}

--- a/Source/DotNET/Fundamentals/Types/Types.cs
+++ b/Source/DotNET/Fundamentals/Types/Types.cs
@@ -54,7 +54,7 @@ public class Types : ITypes
         providers.ForEach(_ => _.Initialize());
         var assemblies = providers.SelectMany(_ => _.Assemblies).Distinct();
         _assemblies.AddRange(assemblies);
-        All = providers.SelectMany(_ => _.DefinedTypes).Distinct();
+        All = providers.SelectMany(static p => SafelyEnumerate(() => p.DefinedTypes)).Distinct();
 
         var precomputedProviders = providers.OfType<ICanProvideContractToImplementorsForDiscovery>().ToArray();
         if (precomputedProviders.Length > 0)
@@ -85,7 +85,7 @@ public class Types : ITypes
             // their implementations are still discoverable.
             var nonPrecomputedTypes = providers
                 .Where(static p => p is not ICanProvideContractToImplementorsForDiscovery)
-                .SelectMany(static p => p.DefinedTypes)
+                .SelectMany(static p => SafelyEnumerate(() => p.DefinedTypes))
                 .Distinct();
             _contractToImplementorsMap.Feed(nonPrecomputedTypes);
 
@@ -97,8 +97,8 @@ public class Types : ITypes
             // discover them without falling back to a full assembly scan.
             var diRegisteredImplementations = providers
                 .OfType<ICanProvideConventionsForDependencyInjection>()
-                .SelectMany(static p => p.SelfBindings.Select(static b => b.ImplementationType)
-                    .Concat(p.ConventionServiceBindings.Select(static b => b.ImplementationType)))
+                .SelectMany(static p => SafelyEnumerate(() => p.SelfBindings.Select(static b => b.ImplementationType)
+                    .Concat(p.ConventionServiceBindings.Select(static b => b.ImplementationType))))
                 .Distinct();
             _contractToImplementorsMap.Feed(diRegisteredImplementations);
 
@@ -139,6 +139,54 @@ public class Types : ITypes
         var typeFound = _contractToImplementorsMap.All.SingleOrDefault(t => t.FullName == fullName);
         ThrowIfTypeNotFound(fullName, typeFound!);
         return typeFound!;
+    }
+
+    /// <summary>
+    /// Enumerates a provider-supplied sequence, tolerating a type that cannot be loaded — for example when a
+    /// referenced assembly resolves to a version that no longer contains a referenced type. Elements collected
+    /// before the failure are kept so type discovery continues instead of crashing application startup.
+    /// </summary>
+    /// <typeparam name="T">Type of element in the sequence.</typeparam>
+    /// <param name="factory">Factory producing the sequence to enumerate.</param>
+    /// <returns>The elements that could be enumerated successfully.</returns>
+    static IEnumerable<T> SafelyEnumerate<T>(Func<IEnumerable<T>> factory)
+    {
+        IEnumerator<T>? enumerator = null;
+        try
+        {
+            enumerator = factory().GetEnumerator();
+        }
+        catch (TypeLoadException)
+        {
+        }
+
+        if (enumerator is null)
+        {
+            yield break;
+        }
+
+        using (enumerator)
+        {
+            while (true)
+            {
+                T current;
+                try
+                {
+                    if (!enumerator.MoveNext())
+                    {
+                        break;
+                    }
+
+                    current = enumerator.Current;
+                }
+                catch (TypeLoadException)
+                {
+                    break;
+                }
+
+                yield return current;
+            }
+        }
     }
 
     void ThrowIfMultipleTypesFound(Type type, IEnumerable<Type> typesFound)


### PR DESCRIPTION
# Summary

Follow-up to #1086: makes type discovery tolerate a provider whose type sequence throws while being enumerated.

## Fixed

- The `Types` constructor no longer crashes application startup when a provider's `DefinedTypes` or `SelfBindings` sequence throws `TypeLoadException` during enumeration (for example a generated provider referencing a type that a resolved assembly version no longer contains). The elements collected before the failure are kept and discovery continues.
