### PR TITLE
Upgrade actions/cache from v3 to v4

### DIFF
--- a/.github/workflows/javascript-build.yml
+++ b/.github/workflows/javascript-build.yml
@@ -42,7 +42,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: "https://registry.npmjs.org"
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: yarn-cache
         with:
           path: |


### PR DESCRIPTION
## Changed

- Continuous integration caching uses `actions/cache@v4`.
