### PR TITLE
Preserve values emitted synchronously when wrapping an observable

### DIFF
--- a/Source/DotNET/Fundamentals.Specs/Reactive/for_ObservableExtensions/when_subscribing_after_the_source_has_emitted.cs
+++ b/Source/DotNET/Fundamentals.Specs/Reactive/for_ObservableExtensions/when_subscribing_after_the_source_has_emitted.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Subjects;
+
+namespace Cratis.Reactive.for_ObservableExtensions;
+
+public class when_subscribing_after_the_source_has_emitted : Specification
+{
+    Subject<string> source;
+    ISubject<string> result;
+    List<string> received;
+
+    void Establish()
+    {
+        source = new();
+        received = [];
+        result = this.InvokeAndWrapWithSubject<string>(_ => source);
+        source.OnNext("emitted before anyone subscribed");
+    }
+
+    void Because() => result.Subscribe(received.Add);
+
+    [Fact] void should_replay_the_most_recent_value_to_the_late_subscriber() => received.ShouldContainOnly("emitted before anyone subscribed");
+}

--- a/Source/DotNET/Fundamentals.Specs/Reactive/for_ObservableExtensions/when_the_wrapping_subject_is_completed.cs
+++ b/Source/DotNET/Fundamentals.Specs/Reactive/for_ObservableExtensions/when_the_wrapping_subject_is_completed.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Subjects;
+
+namespace Cratis.Reactive.for_ObservableExtensions;
+
+public class when_the_wrapping_subject_is_completed : Specification
+{
+    Subject<string> source;
+    ISubject<string> result;
+    CancellationToken tokenPassedToTheAction;
+    bool sourceStillHasObservers;
+
+    void Establish()
+    {
+        source = new();
+        result = this.InvokeAndWrapWithSubject<string>(token =>
+        {
+            tokenPassedToTheAction = token;
+            return source;
+        });
+    }
+
+    void Because()
+    {
+        result.OnCompleted();
+        sourceStillHasObservers = source.HasObservers;
+    }
+
+    [Fact] void should_cancel_the_token_handed_to_the_action() => tokenPassedToTheAction.IsCancellationRequested.ShouldBeTrue();
+
+    [Fact] void should_unsubscribe_from_the_source() => sourceStillHasObservers.ShouldBeFalse();
+}

--- a/Source/DotNET/Fundamentals.Specs/Reactive/for_ObservableExtensions/when_transforming_a_source_that_emits_synchronously_on_subscribe.cs
+++ b/Source/DotNET/Fundamentals.Specs/Reactive/for_ObservableExtensions/when_transforming_a_source_that_emits_synchronously_on_subscribe.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Subjects;
+
+namespace Cratis.Reactive.for_ObservableExtensions;
+
+public class when_transforming_a_source_that_emits_synchronously_on_subscribe : Specification
+{
+    BehaviorSubject<IEnumerable<string>> source;
+    ISubject<IEnumerable<string>> result;
+    List<IEnumerable<string>> received;
+
+    void Establish()
+    {
+        source = new(["first", "second"]);
+        received = [];
+    }
+
+    void Because()
+    {
+        result = this.InvokeAndWrapWithTransformSubject<IEnumerable<string>, IEnumerable<string>>(
+            _ => source,
+            values => values.Select(value => value.ToUpperInvariant()));
+        result.Subscribe(received.Add);
+    }
+
+    [Fact] void should_deliver_one_value() => received.Count.ShouldEqual(1);
+
+    [Fact] void should_transform_the_value_the_source_emitted_before_anyone_subscribed() => received[0].ShouldContainOnly("FIRST", "SECOND");
+}

--- a/Source/DotNET/Fundamentals.Specs/Reactive/for_ObservableExtensions/when_wrapping_a_source_that_emits_synchronously_on_subscribe.cs
+++ b/Source/DotNET/Fundamentals.Specs/Reactive/for_ObservableExtensions/when_wrapping_a_source_that_emits_synchronously_on_subscribe.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Subjects;
+
+namespace Cratis.Reactive.for_ObservableExtensions;
+
+public class when_wrapping_a_source_that_emits_synchronously_on_subscribe : Specification
+{
+    BehaviorSubject<string> source;
+    ISubject<string> result;
+    List<string> received;
+
+    void Establish()
+    {
+        source = new("initial");
+        received = [];
+    }
+
+    void Because()
+    {
+        result = this.InvokeAndWrapWithSubject<string>(_ => source);
+        result.Subscribe(received.Add);
+    }
+
+    [Fact] void should_deliver_the_value_the_source_emitted_before_anyone_subscribed() => received.ShouldContainOnly("initial");
+}

--- a/Source/DotNET/Fundamentals.Specs/Reactive/for_TransformingSubject/when_the_source_emits_synchronously_on_subscribe.cs
+++ b/Source/DotNET/Fundamentals.Specs/Reactive/for_TransformingSubject/when_the_source_emits_synchronously_on_subscribe.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.Reactive.Subjects;
+
+namespace Cratis.Reactive.for_TransformingSubject;
+
+public class when_the_source_emits_synchronously_on_subscribe : Specification
+{
+    BehaviorSubject<int> source;
+    TransformingSubject<int, string> subject;
+    List<string> received;
+
+    void Establish()
+    {
+        source = new(42);
+        received = [];
+    }
+
+    void Because()
+    {
+        subject = new(source, value => value.ToString(CultureInfo.InvariantCulture));
+        subject.Subscribe(received.Add);
+    }
+
+    [Fact] void should_deliver_the_value_the_source_emitted_during_construction() => received.ShouldContainOnly("42");
+}

--- a/Source/DotNET/Fundamentals/Reactive/ObservableExtensions.cs
+++ b/Source/DotNET/Fundamentals/Reactive/ObservableExtensions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
 using System.Reactive.Subjects;
 
 namespace Cratis.Reactive;
@@ -30,25 +32,19 @@ public static class ObservableExtensions
     /// <param name="action">The action to invoke that returns an observable.</param>
     /// <typeparam name="TResult">Type of result.</typeparam>
     /// <returns>The subject.</returns>
+    /// <remarks>
+    /// The returned subject replays its most recent value to whoever subscribes to it. Callers wrap an observable
+    /// here and hand the subject on to a consumer that subscribes later, so a source emitting synchronously while
+    /// it is being subscribed - a <see cref="BehaviorSubject{T}"/> seed, a <see cref="ReplaySubject{T}"/> buffer,
+    /// anything backed by in-memory state - would otherwise emit into a subject nobody is listening to yet and the
+    /// value would be lost for good.
+    /// </remarks>
 #pragma warning disable RCS1175 // Unused 'this' parameter
 #pragma warning disable IDE0060 // Remove unused parameter
     public static ISubject<TResult> InvokeAndWrapWithSubject<TResult>(this object instance, Func<CancellationToken, IObservable<TResult>> action)
 #pragma warning restore IDE0060 // Remove unused parameter
 #pragma warning restore RCS1175 // Unused 'this' parameter
-    {
-#pragma warning disable CA2000 // Dispose objects before losing scope
-        var cts = new CancellationTokenSource();
-#pragma warning restore CA2000 // Dispose objects before losing scope
-        var subject = new Subject<TResult>();
-        var observable = action(cts.Token);
-        observable.Subscribe(subject);
-        subject.Subscribe(_ => { }, _ => { }, () =>
-        {
-            cts.Cancel();
-            cts.Dispose();
-        });
-        return subject;
-    }
+        => WrapWithReplayingSubject(action, observable => observable);
 
     /// <summary>
     /// Invokes an action and wraps the observable result in a subject providing, with a cancellation token passed to the action that cancels when the subject is completed.
@@ -59,25 +55,39 @@ public static class ObservableExtensions
     /// <typeparam name="TResult">Type of result.</typeparam>
     /// <typeparam name="TSource">Type of source.</typeparam>
     /// <returns>The subject.</returns>
+    /// <remarks>
+    /// The returned subject replays its most recent value - see <see cref="InvokeAndWrapWithSubject{TResult}"/> for why.
+    /// </remarks>
 #pragma warning disable RCS1175 // Unused 'this' parameter
 #pragma warning disable IDE0060 // Remove unused parameter
     public static ISubject<TResult> InvokeAndWrapWithTransformSubject<TResult, TSource>(this object instance, Func<CancellationToken, IObservable<TSource>> action, Func<TSource, TResult> transform)
 #pragma warning restore IDE0060 // Remove unused parameter
 #pragma warning restore RCS1175 // Unused 'this' parameter
+        => WrapWithReplayingSubject(action, observable => observable.Select(transform));
+
+    static ReplaySubject<TResult> WrapWithReplayingSubject<TResult, TSource>(
+        Func<CancellationToken, IObservable<TSource>> action,
+        Func<IObservable<TSource>, IObservable<TResult>> compose)
     {
+        // Both the token source and the subscription live for as long as the returned subject does and are
+        // disposed when it completes, which is beyond the scope the analyzer can see.
 #pragma warning disable CA2000 // Dispose objects before losing scope
         var cts = new CancellationTokenSource();
+        var subject = new ReplaySubject<TResult>(1);
+
+        // Assigned after the completion handler is wired up, so a source that completes synchronously still gets
+        // its subscription disposed - SingleAssignmentDisposable disposes whatever is assigned to it afterwards.
+        var subscription = new SingleAssignmentDisposable();
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
-        var sourceObservable = action(cts.Token);
-        var sourceSubject = new Subject<TSource>();
-        sourceObservable.Subscribe(sourceSubject);
-        var subject = new TransformingSubject<TSource, TResult>(sourceSubject, transform);
         subject.Subscribe(_ => { }, _ => { }, () =>
         {
+            subscription.Dispose();
             cts.Cancel();
             cts.Dispose();
         });
+
+        subscription.Disposable = compose(action(cts.Token)).Subscribe(subject);
         return subject;
     }
 }

--- a/Source/DotNET/Fundamentals/Reactive/TransformingSubject.cs
+++ b/Source/DotNET/Fundamentals/Reactive/TransformingSubject.cs
@@ -11,10 +11,16 @@ namespace Cratis.Reactive;
 /// </summary>
 /// <typeparam name="TSource">Type of source.</typeparam>
 /// <typeparam name="TResult">Type of converted result.</typeparam>
+/// <remarks>
+/// The transformed result replays its most recent value to whoever subscribes. The source is subscribed to during
+/// construction, before any consumer can have attached, so a source emitting synchronously on subscribe - a
+/// <see cref="BehaviorSubject{T}"/> seed, a <see cref="ReplaySubject{T}"/> buffer - would otherwise have that first
+/// value dropped on the floor.
+/// </remarks>
 public class TransformingSubject<TSource, TResult> : ISubject<TResult>, IDisposable
 {
     readonly ISubject<TSource> _sourceSubject;
-    readonly Subject<TResult> _resultSubject;
+    readonly ReplaySubject<TResult> _resultSubject;
 
     /// <summary>
     /// Initializes a new instance of <see cref="TransformingSubject{TSource, TResult}"/>.
@@ -24,7 +30,7 @@ public class TransformingSubject<TSource, TResult> : ISubject<TResult>, IDisposa
     public TransformingSubject(ISubject<TSource> sourceSubject, Func<TSource, TResult> transform)
     {
         _sourceSubject = sourceSubject;
-        _resultSubject = new Subject<TResult>();
+        _resultSubject = new ReplaySubject<TResult>(1);
         _sourceSubject.Select(transform).Subscribe(_resultSubject);
         sourceSubject.Subscribe(_ => { }, _ => { }, Dispose);
     }


### PR DESCRIPTION
# Summary

Observable queries backed by an in-memory store silently returned nothing. The wrappers in `Cratis.Reactive` subscribed the source into a plain `Subject` before any consumer could attach, so a source that emits *while it is being subscribed* — a `BehaviorSubject` seed, a `ReplaySubject` buffer, anything reading in-memory state — pushed its value into a subject with no observers, and it was lost for good. Sources whose first value arrives asynchronously (a database round-trip) were unaffected, which is why this only ever surfaced against in-memory backing stores.

## Fixed

- Observable queries no longer lose the value their source emits synchronously on subscribe. `InvokeAndWrapWithSubject`, `InvokeAndWrapWithTransformSubject`, and `TransformingSubject` now buffer the most recent value, so the consumer that subscribes after wrapping still receives the current state.
- The source subscription is now disposed when the wrapping subject completes, instead of leaking for the lifetime of the source.

## Changed

- Subjects returned by `InvokeAndWrapWithSubject` and `InvokeAndWrapWithTransformSubject`, and `TransformingSubject` itself, replay their most recent value to new subscribers. A subscriber attaching after a value has been produced now sees the current state rather than waiting for the next change.