### PR TITLE
Let spec files inherit the decorator setting from the root tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,7 +41,6 @@
         "newLine": "lf"
     },
     "exclude": [
-        "**/dist",
-        "**/for_*/**"
+        "**/dist"
     ]
 }


### PR DESCRIPTION
# Summary

The JavaScript build has been failing for every spec that uses a decorator.

## Fixed

- Spec files now inherit `experimentalDecorators` from the root `tsconfig.json`, so the Vite/Oxc transform handles decorator syntax instead of leaving it for Node to reject with `SyntaxError: Invalid or unexpected token`. 16 of 75 spec files could not load before this.
