### PR TITLE
Support standard TypeScript decorators

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,6 @@
     <PackageVersion Include="System.Reactive" Version="7.0.0" />
     <PackageVersion Include="Humanizer" Version="3.0.10" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.400" />
-    <PackageVersion Include="handlebars.net" Version="2.1.6" />
     <PackageVersion Include="OneOf" Version="3.0.271" />
     <PackageVersion Include="OneOf.SourceGenerator" Version="3.0.271" />
     <!-- Roslyn-->

--- a/Documentation/typescript/serialization/derived_types.md
+++ b/Documentation/typescript/serialization/derived_types.md
@@ -18,7 +18,7 @@ The frontend DerivedTypes system consists of:
 
 ### Type Metadata System
 
-The frontend uses TypeScript decorators and reflect-metadata to store type information:
+The frontend uses TypeScript decorators and Fundamentals' metadata support to store type information:
 
 - **Derived Type IDs**: Unique string identifiers that must match exactly with backend `[DerivedType]` attributes
 - **Field Metadata**: Information about properties including their types and possible derivatives
@@ -275,9 +275,9 @@ export class CreditCard implements IPaymentMethod {
     // ❌ This won't be serialized without @field
     private internalId: string = '';
 
-    // ✅ Private fields that should be serialized need @field too
+    // Public serializable fields use @field
     @field(String)
-    private securityCode!: string;
+    cardIssuer!: string;
 }
 ```
 
@@ -375,32 +375,13 @@ With derived types, you benefit from:
 - **Type scanning**: Keep derivative lists focused to avoid unnecessary type checking
 - **Memory usage**: Metadata is stored per-class, not per-instance
 
-## Integration with Build Tools
+## Decorator Compatibility
 
-### TypeScript Configuration
+`@derivedType` supports both legacy and standard decorators. `Fields` merges metadata recorded by both modes across inheritance, so base and derived classes may come from dependencies compiled with different decorator modes. A project may still choose one compiler mode for consistency. See [Decorator Modes](./field_decorator.md#decorator-modes) for the TypeScript and Babel configuration.
 
-Ensure your `tsconfig.json` includes:
-
-```json
-{
-  "compilerOptions": {
-    "experimentalDecorators": true,
-    "emitDecoratorMetadata": true
-  }
-}
-```
-
-### Bundling Considerations
-
-When using module bundlers, ensure reflect-metadata is properly included:
-
-```typescript
-import 'reflect-metadata';
-// Import this before any decorated classes
-```
+Fundamentals loads its metadata support when you import `derivedType`; you do not need a separate `reflect-metadata` import.
 
 ## See Also
 
 - [JsonSerializer](./json_serializer.md) - Core serialization utility for type-safe JSON conversion
 - [Field Decorator](./field_decorator.md) - Comprehensive guide to the `@field` decorator system and runtime type safety
-

--- a/Documentation/typescript/serialization/derived_types.md
+++ b/Documentation/typescript/serialization/derived_types.md
@@ -205,8 +205,8 @@ isActive!: boolean;
 
 1. **Missing `@derivedType` decorator**: Classes won't be recognized during deserialization
 2. **Mismatched IDs**: Frontend and backend derived type IDs must match exactly
-3. **Missing field decorators**: Properties without `@field` won't be serialized/deserialized
-4. **Missing derivatives list**: Polymorphic fields need the derivatives parameter
+3. **Missing field decorators**: Runtime own properties are serialized even without `@field`, but they have no typed deserialization metadata
+4. **Missing derivatives list for an interface-shaped field**: Erased interfaces cannot provide a runtime constructor, so their possible implementations must be explicit
 
 ### Debugging Tips
 
@@ -260,9 +260,9 @@ export class PayPal implements IPaymentMethod { }
 
 > **Why centralize?** These "magic strings" are critical for serialization consistency. Centralizing them in one place prevents duplicates, makes them easy to maintain, and ensures frontend and backend stay synchronized.
 
-### 3. Complete Field Decoration
+### 3. Typed Field Metadata
 
-Decorate all serializable properties:
+Decorate every public field that requires typed deserialization. Runtime own properties also serialize without `@field`, but concrete-class deserialization only populates declared fields and cannot convert an undecorated value to its intended runtime type.
 
 ```typescript
 export class CreditCard implements IPaymentMethod {
@@ -272,8 +272,8 @@ export class CreditCard implements IPaymentMethod {
     @field(String)
     cardNumber!: string;
 
-    // ❌ This won't be serialized without @field
-    private internalId: string = '';
+    // This runtime own property is serialized, but has no typed deserialization metadata
+    transientNote: string = '';
 
     // Public serializable fields use @field
     @field(String)
@@ -281,19 +281,21 @@ export class CreditCard implements IPaymentMethod {
 }
 ```
 
-### 4. Explicit Derivative Lists
+### 4. Derivative Lists for Erased Types
 
-Always specify derivatives for polymorphic fields:
+Specify derivatives for interface-shaped fields because TypeScript erases the interface at runtime:
 
 ```typescript
 // ✅ Good - explicit derivatives list
 @field(Object, false, [CreditCard, PayPal])
 paymentMethod!: IPaymentMethod;
 
-// ❌ Bad - missing derivatives, won't deserialize correctly
+// Missing runtime candidates for an erased interface
 @field(Object)
 paymentMethod!: IPaymentMethod;
 ```
+
+A field typed with a concrete base class can omit the explicit list when each implementation uses `@derivedType`. The decorator automatically registers subclasses through the class inheritance chain.
 
 ### 5. Interface Consistency
 

--- a/Documentation/typescript/serialization/field_decorator.md
+++ b/Documentation/typescript/serialization/field_decorator.md
@@ -80,7 +80,7 @@ Set `experimentalDecorators` to `true` for the legacy TypeScript transform:
 
 ### Standard TypeScript Decorators
 
-Omit `experimentalDecorators`, or set it to `false`, to use standard decorators:
+Standard decorator metadata support requires TypeScript 5.2 or later. Omit `experimentalDecorators`, or set it to `false`, to use standard decorators:
 
 ```json
 {

--- a/Documentation/typescript/serialization/field_decorator.md
+++ b/Documentation/typescript/serialization/field_decorator.md
@@ -1,6 +1,6 @@
 # `@field` Decorator
 
-The `@field` decorator supplies the runtime type information that `JsonSerializer` uses to serialize and deserialize class fields. The same decorator supports TypeScript's legacy decorator transform and the standard decorator transform.
+The `@field` decorator supplies the runtime type information that `JsonSerializer` uses to deserialize class fields into their declared runtime types. The same decorator supports TypeScript's legacy decorator transform and the standard decorator transform.
 
 ## Signature
 

--- a/Documentation/typescript/serialization/field_decorator.md
+++ b/Documentation/typescript/serialization/field_decorator.md
@@ -1,497 +1,213 @@
-# @field Decorator
+# `@field` Decorator
 
-The `@field` decorator is a fundamental component of the TypeScript serialization system that provides runtime type information and enables proper object deserialization with full type safety.
+The `@field` decorator supplies the runtime type information that `JsonSerializer` uses to serialize and deserialize class fields. The same decorator supports TypeScript's legacy decorator transform and the standard decorator transform.
 
-## Overview
+## Signature
 
-The `@field` decorator system transforms TypeScript's compile-time type information into runtime metadata, enabling runtime type safety and proper deserialization. It works seamlessly with the `JsonSerializer` for complete type-safe serialization.
+```typescript
+field(
+    targetType: Constructor,
+    enumerable?: boolean,
+    derivatives?: Constructor[],
+    genericArguments?: Constructor[]
+)
 
-Key capabilities:
+field(
+    targetType: Constructor,
+    options?: {
+        enumerable?: boolean;
+        derivatives?: Constructor[];
+        genericArguments?: Constructor[];
+    }
+)
+```
 
-- **Runtime Type Metadata**: Compile-time types converted to runtime metadata
-- **Proper Deserialization**: Works with `JsonSerializer` to create actual class instances
-- **Type-Safe Collections**: Proper typing for arrays and complex nested objects
-- **Deep Object Graphs**: Maintaining correct types throughout complex object hierarchies
+| Parameter | Description | Default |
+|---|---|---|
+| `targetType` | Runtime constructor for the field value, such as `String`, `Date`, or a custom class. | Required |
+| `enumerable` | Indicates that the field contains a collection of `targetType` values. | `false` |
+| `derivatives` | Constructors that may occur in a polymorphic field. | `[]` |
+| `genericArguments` | Runtime constructors for generic type arguments. | `[]` |
 
-## Basic Usage
+The constructor argument is always explicit. `@field(String)`, for example, records `String` directly and does not depend on emitted `design:type` metadata.
 
-### Simple Field Declaration
+## Supported Fields
+
+Apply `@field` to public instance fields with string names.
+
+The supported surface does not include:
+
+- static fields;
+- ECMAScript private fields declared with `#`;
+- symbol-named fields;
+- declarations that are not fields.
+
+Methods do not need `@field`. Leave implementation-only state undecorated.
 
 ```typescript
 import { field } from '@cratis/fundamentals';
 
-export class User {
-    @field(String)
-    name!: string;
-    
-    @field(Number)
-    age!: number;
-    
-    @field(Boolean)
-    isActive!: boolean;
-    
-    @field(Date)
-    createdAt!: Date;
-    
-    // Method available on deserialized instances
-    getDisplayName(): string {
-        return `${this.name} (${this.age})`;
-    }
-}
-```
-
-### Decorator Parameters
-
-The `@field` decorator supports positional parameters and an options object.
-
-```typescript
-@field(targetType: Constructor, enumerable?: boolean, derivatives?: Constructor[])
-@field(targetType: Constructor, { enumerable?: boolean, derivatives?: Constructor[], genericArguments?: Constructor[] })
-```
-
-- **`targetType`**: The type constructor for the field (String, Number, Date, custom classes, etc.)
-- **`enumerable`**: Set to `true` for arrays/collections (default: `false`)
-- **`derivatives`**: Array of possible derived types for polymorphic fields (default: `[]`)
-- **`genericArguments`**: Generic type metadata for specialized types such as `ValueMap<TKey, TValue>`
-
-## Field Types
-
-### Primitive Types
-
-```typescript
 export class Product {
     @field(String)
     name!: string;
-    
+
     @field(Number)
     price!: number;
-    
-    @field(Boolean)
-    inStock!: boolean;
-    
-    @field(Date)
-    lastUpdated!: Date;
-    
-    @field(Guid)
-    id!: Guid;
+
+    calculateTax(rate: number): number {
+        return this.price * rate;
+    }
 }
 ```
 
-### Array Fields
+## Decorator Modes
 
-Use the `enumerable: true` parameter for arrays:
+The source syntax is identical in both modes. Your compiler configuration determines which decorator protocol calls `@field`.
+
+### Legacy TypeScript Decorators
+
+Set `experimentalDecorators` to `true` for the legacy TypeScript transform:
+
+```json
+{
+  "compilerOptions": {
+    "experimentalDecorators": true
+  }
+}
+```
+
+`@field` does not require `emitDecoratorMetadata`, because every use supplies its runtime constructor explicitly. Other libraries in your application may still require that legacy option.
+
+### Standard TypeScript Decorators
+
+Omit `experimentalDecorators`, or set it to `false`, to use standard decorators:
+
+```json
+{
+  "compilerOptions": {
+    "experimentalDecorators": false,
+    "emitDecoratorMetadata": false
+  }
+}
+```
+
+Standard decorators do not support `emitDecoratorMetadata`. `@field` does not need it.
+
+With standard decorators, metadata is recorded while the class definition is evaluated and exposed through `Symbol.metadata`. Fundamentals defines `Symbol.metadata` on runtimes that do not provide it, so `Fields` and `JsonSerializer` can read field metadata before the first class instance is constructed. Importing `field` loads this support; you do not need a separate `reflect-metadata` import.
+
+### Babel, Expo, and Hermes
+
+If Babel compiles your decorated classes, configure `@babel/plugin-proposal-decorators` with `version: "2023-11"` for standard decorators. Expo applications normally receive decorator support through `babel-preset-expo`; keep the preset current and let Babel transform decorators before Hermes executes the output. Hermes should not be treated as a native decorator transform.
+
+## Field Types
+
+### Primitive and Custom Types
+
+```typescript
+import { field, Guid } from '@cratis/fundamentals';
+
+export class Address {
+    @field(String)
+    city!: string;
+}
+
+export class Customer {
+    @field(Guid)
+    id!: Guid;
+
+    @field(String)
+    name!: string;
+
+    @field(Date)
+    registeredAt!: Date;
+
+    @field(Address)
+    address!: Address;
+}
+```
+
+### Collections
+
+Set `enumerable` to `true` for arrays:
 
 ```typescript
 export class ShoppingCart {
-    @field(String, true) // Array of strings
+    @field(String, true)
     tags!: string[];
-    
-    @field(Number, true) // Array of numbers
-    quantities!: number[];
-    
-    @field(Product, true) // Array of custom objects
-    items!: Product[];
-}
-```
 
-### Complex Objects
-
-```typescript
-export class Order {
-    @field(String)
-    orderId!: string;
-    
-    @field(User) // Nested object
-    customer!: User;
-    
-    @field(Product, true) // Array of objects
-    items!: Product[];
-    
-    @field(Date)
-    orderDate!: Date;
-    
-    calculateTotal(): number {
-        return this.items.reduce((sum, item) => sum + item.price, 0);
-    }
+    @field(Product, { enumerable: true })
+    products!: Product[];
 }
 ```
 
 ### Polymorphic Fields
 
-For interfaces or base classes with multiple implementations, specify the possible derived types:
+Supply the possible runtime constructors for an interface-shaped or base-typed field:
 
 ```typescript
-export interface IPaymentMethod {
+import { derivedType, field } from '@cratis/fundamentals';
+
+export interface PaymentMethod {
     amount: number;
 }
 
-@derivedType('credit-card-v1')
-export class CreditCard implements IPaymentMethod {
+@derivedType('card')
+export class CardPayment implements PaymentMethod {
     @field(Number)
     amount!: number;
-    
+
     @field(String)
-    cardNumber!: string;
+    lastFourDigits!: string;
 }
 
-@derivedType('paypal-v1')
-export class PayPal implements IPaymentMethod {
+@derivedType('invoice')
+export class InvoicePayment implements PaymentMethod {
     @field(Number)
     amount!: number;
-    
+
     @field(String)
-    email!: string;
+    invoiceNumber!: string;
 }
 
 export class Payment {
-    @field(Object, false, [CreditCard, PayPal]) // Single polymorphic field
-    method!: IPaymentMethod;
-    
-    @field(Object, true, [CreditCard, PayPal]) // Array of polymorphic objects
-    backupMethods!: IPaymentMethod[];
+    @field(Object, { derivatives: [CardPayment, InvoicePayment] })
+    method!: PaymentMethod;
+
+    @field(Object, {
+        enumerable: true,
+        derivatives: [CardPayment, InvoicePayment]
+    })
+    alternatives!: PaymentMethod[];
 }
 ```
 
-## Runtime Type Safety Benefits
+See [Derived Types](./derived_types.md) for derived type identifiers and runtime resolution.
 
-### Traditional JavaScript Object Limitations
+## Inheritance
 
-Without the `@field` decorator system, JSON deserialization creates plain JavaScript objects:
+`Fields.getFieldsForType()` includes fields declared by base classes and derived classes. If a derived class redeclares a field with the same name, its declaration replaces the base declaration for that derived type without changing the base type's metadata.
 
-```typescript
-// Traditional approach - no runtime type safety
-const json = `{"name": "John", "age": 30, "createdAt": "2023-01-01T00:00:00Z"}`;
-const user = JSON.parse(json) as User;
+This behavior is the same for legacy and standard decorators.
 
-console.log(user.constructor.name); // "Object" - not User!
-console.log(user instanceof User); // false
-user.getDisplayName(); // ❌ Runtime error - method doesn't exist
-typeof user.createdAt; // "string" - not Date object
-```
+## Runtime Inspection
 
-### With @field Decorator - True Runtime Types
-
-The `@field` decorator system creates actual class instances with full method access:
+Use `Fields.getFieldsForType()` to inspect the metadata recorded for a class:
 
 ```typescript
-// With @field system - full runtime type safety
-const json = `{"name": "John", "age": 30, "createdAt": "2023-01-01T00:00:00Z"}`;
-const user = JsonSerializer.deserialize(User, json);
+import { Fields } from '@cratis/fundamentals';
 
-console.log(user.constructor.name); // "User" ✅
-console.log(user instanceof User); // true ✅
-console.log(user.getDisplayName()); // "John (30)" ✅ - method available
-console.log(user.createdAt instanceof Date); // true ✅ - proper Date object
-```
-
-### Polymorphic Runtime Type Resolution
-
-The system automatically resolves derived types at runtime based on the `_derivedTypeId`:
-
-```typescript
-export class PaymentProcessor {
-    @field(Object, true, [CreditCard, PayPal])
-    supportedMethods!: IPaymentMethod[];
-    
-    processPayments(): void {
-        this.supportedMethods.forEach(method => {
-            // Each method is the correct runtime type
-            if (method instanceof CreditCard) {
-                // Full CreditCard methods available
-                console.log(`Processing card: ${method.cardNumber}`);
-                method.validateCard(); // Method available at runtime
-            } else if (method instanceof PayPal) {
-                // Full PayPal methods available
-                console.log(`Processing PayPal: ${method.email}`);
-                method.validateEmail(); // Method available at runtime
-            }
-        });
-    }
-}
-```
-
-### Deep Object Graphs with Runtime Types
-
-Complex nested objects maintain their proper types throughout the object graph:
-
-```typescript
-export class Customer {
-    @field(String)
-    name!: string;
-    
-    @field(Order, true)
-    orders!: Order[];
-    
-    @field(Object, false, [CreditCard, PayPal])
-    defaultPayment!: IPaymentMethod;
-    
-    getTotalSpent(): number {
-        // All nested objects are proper runtime types
-        return this.orders.reduce((total, order) => total + order.calculateTotal(), 0);
-    }
-    
-    hasValidPayment(): boolean {
-        return this.defaultPayment instanceof CreditCard 
-            ? this.defaultPayment.validateCard()
-            : this.defaultPayment.validateEmail();
-    }
-}
-```
-
-### Data Validation and Business Rules
-
-Runtime types enable rich validation and business logic on deserialized data:
-
-```typescript
-export class BankAccount {
-    @field(String)
-    accountNumber!: string;
-    
-    @field(String)
-    routingNumber!: string;
-    
-    @field(Number)
-    balance!: number;
-    
-    @field(Date)
-    lastTransaction!: Date;
-    
-    validateAccountNumber(): boolean {
-        // Complex validation logic available on runtime instances
-        return this.accountNumber.length >= 4 && this.accountNumber.length <= 17;
-    }
-    
-    validateRoutingNumber(): boolean {
-        return /^\d{9}$/.test(this.routingNumber);
-    }
-    
-    canWithdraw(amount: number): boolean {
-        return this.balance >= amount && this.validateAccountNumber();
-    }
-    
-    getAccountAge(): number {
-        // Business logic methods work on deserialized instances
-        const now = new Date();
-        return Math.floor((now.getTime() - this.lastTransaction.getTime()) / (1000 * 60 * 60 * 24));
-    }
-}
-
-// Usage with deserialized data
-const accountData = `{
-    "accountNumber": "1234567890",
-    "routingNumber": "123456789",
-    "balance": 1500.50,
-    "lastTransaction": "2023-10-01T10:30:00Z"
-}`;
-
-const account = JsonSerializer.deserialize(BankAccount, accountData);
-
-// All methods work on the deserialized instance
-console.log(account.validateAccountNumber()); // true
-console.log(account.canWithdraw(1000)); // true
-console.log(account.getAccountAge()); // Number of days
-console.log(account.lastTransaction instanceof Date); // true
-```
-
-## Serialization and Deserialization
-
-For detailed information about serialization and deserialization operations, see the [JsonSerializer Documentation](./json_serializer.md).
-
-## Type System Integration
-
-### Working with TypeScript's Type System
-
-```typescript
-// Type-safe polymorphic handling
-function processPayment(payment: IPaymentMethod): void {
-    if (payment instanceof CreditCard) {
-        // TypeScript knows this is CreditCard
-        console.log(`Processing card: ${payment.cardNumber}`);
-    } else if (payment instanceof PayPal) {
-        // TypeScript knows this is PayPal
-        console.log(`Processing PayPal: ${payment.email}`);
-    }
-}
-
-// Type guards for runtime checking
-function isCreditCard(payment: IPaymentMethod): payment is CreditCard {
-    return payment instanceof CreditCard; // Works with runtime types
-}
-```
-
-### Generic Serialization
-
-```typescript
-// Generic deserialization helper
-function deserializeCollection<T extends object>(
-    json: string,
-    targetType: Constructor<T>
-): T[] {
-    return JsonSerializer.deserializeArray(targetType, json);
-}
-
-const products = deserializeCollection(json, Product);
-const users = deserializeCollection(userJson, User);
-```
-
-## Best Practices
-
-### 1. Complete Field Decoration
-
-Decorate all serializable properties:
-
-```typescript
-export class Product {
-    @field(String)
-    name!: string;
-    
-    @field(Number)
-    price!: number;
-    
-    // ❌ This won't be serialized without @field
-    private internalId: string = '';
-    
-    // ✅ Private fields that should be serialized need @field too
-    @field(String)
-    private sku!: string;
-    
-    // ✅ Methods don't need @field - they're part of the class
-    calculateTax(): number {
-        return this.price * 0.08;
-    }
-}
-```
-
-### 2. Explicit Type Specification
-
-Always specify the correct target type:
-
-```typescript
-// ✅ Good - explicit type
-@field(Date)
-createdAt!: Date;
-
-@field(Guid)
-id!: Guid;
-
-// ✅ Good - explicit derivatives for polymorphic fields
-@field(Object, false, [CreditCard, PayPal])
-paymentMethod!: IPaymentMethod;
-
-// ❌ Bad - missing derivatives, won't deserialize correctly
-@field(Object)
-paymentMethod!: IPaymentMethod;
-```
-
-### 3. Array Handling
-
-Use the enumerable parameter correctly:
-
-```typescript
-// ✅ Good - enumerable: true for arrays
-@field(String, true)
-tags!: string[];
-
-@field(Product, true)
-items!: Product[];
-
-// ❌ Bad - missing enumerable parameter
-@field(String)
-tags!: string[]; // Won't deserialize array properly
-```
-
-### 4. Testing Serialization Round-trips
-
-Always test serialization and deserialization:
-
-```typescript
-describe('Product serialization', () => {
-    it('should serialize and deserialize correctly', () => {
-        const original = new Product();
-        original.name = "Test Product";
-        original.price = 99.99;
-        
-        const json = JsonSerializer.serialize(original);
-        const deserialized = JsonSerializer.deserialize(Product, json);
-        
-        expect(deserialized.constructor).toBe(Product);
-        expect(deserialized.name).toBe("Test Product");
-        expect(deserialized.price).toBe(99.99);
-        expect(deserialized.calculateTax()).toBe(7.9992); // Method works
-    });
-});
-```
-
-## Comparison: With vs Without @field Decorator
-
-| Aspect | Without @field | With @field |
-|--------|---------------|-------------|
-| **Runtime Type** | Plain Object | Actual Class Instance |
-| **instanceof checks** | ❌ Always false | ✅ Works correctly |
-| **Method access** | ❌ Runtime errors | ✅ Full method access |
-| **Polymorphism** | ❌ Manual type checking | ✅ Automatic resolution |
-| **Type safety** | ❌ Compile-time only | ✅ Runtime + compile-time |
-| **Business logic** | ❌ External functions | ✅ Encapsulated methods |
-| **Validation** | ❌ Manual/external | ✅ Built-in methods |
-| **Debugging** | ❌ Generic objects | ✅ Named class instances |
-| **Date handling** | ❌ Strings | ✅ Proper Date objects |
-| **Nested objects** | ❌ Plain objects | ✅ Proper class instances |
-
-## Error Handling
-
-### Common Issues
-
-1. **Missing @field decorator**: Properties without `@field` won't be serialized/deserialized
-2. **Wrong target type**: Incorrect type specification leads to deserialization errors
-3. **Missing enumerable flag**: Arrays won't deserialize properly without `enumerable: true`
-4. **Missing derivatives**: Polymorphic fields need the derivatives parameter
-
-### Debugging Tips
-
-```typescript
-// Check field metadata for a type
 const fields = Fields.getFieldsForType(Product);
-console.log('Product fields:', fields);
 
-// Verify field configuration
-fields.forEach(field => {
-    console.log(`Field: ${field.name}, Type: ${field.type.name}, Enumerable: ${field.enumerable}`);
-});
-```
-
-## Performance Considerations
-
-- **Metadata overhead**: Field metadata is stored per-class, not per-instance
-- **Reflection cost**: Type resolution happens during deserialization
-- **Memory efficiency**: Keep derivative lists focused to relevant types only
-- **Lazy loading**: Consider lazy initialization for heavy objects
-
-## Integration Requirements
-
-### TypeScript Configuration
-
-Ensure your `tsconfig.json` includes:
-
-```json
-{
-  "compilerOptions": {
-    "experimentalDecorators": true,
-    "emitDecoratorMetadata": true
-  }
+for (const productField of fields) {
+    console.log(productField.name);
+    console.log(productField.type);
+    console.log(productField.enumerable);
 }
 ```
 
-### Runtime Dependencies
-
-```typescript
-import 'reflect-metadata';
-// Import this before any decorated classes
-```
-
-The `@field` decorator system provides a robust foundation for type-safe serialization in TypeScript applications, working together with the `JsonSerializer` to bridge the gap between compile-time type safety and runtime object integrity.
+Each returned `Field` contains `name`, `type`, `enumerable`, `derivatives`, and `genericArguments`.
 
 ## See Also
 
-- [JsonSerializer](./json_serializer.md) - Core serialization utility for type-safe JSON conversion
-- [Derived Types](./derived_types.md) - Polymorphic type handling and interface implementations
-
+- [JsonSerializer](./json_serializer.md) - Serialization and deserialization APIs
+- [Derived Types](./derived_types.md) - Polymorphic type registration and resolution

--- a/Source/DotNET/Fundamentals.Specs/Concepts/for_ConceptAs/when_comparing_concepts.cs
+++ b/Source/DotNET/Fundamentals.Specs/Concepts/for_ConceptAs/when_comparing_concepts.cs
@@ -8,7 +8,7 @@ namespace Cratis.Concepts.for_ConceptAs;
 public class when_comparing_concepts : Specification
 {
     [Fact]
-    public void equal_concepts_should_be_equal()
+    public void should_consider_equal_concepts_equal()
     {
         var conceptA = new IntConcept(42);
         var conceptB = new IntConcept(42);
@@ -18,7 +18,7 @@ public class when_comparing_concepts : Specification
     }
 
     [Fact]
-    public void unequal_concepts_should_not_be_equal()
+    public void should_consider_unequal_concepts_unequal()
     {
         var conceptA = new IntConcept(42);
         var conceptB = new IntConcept(24);
@@ -28,7 +28,7 @@ public class when_comparing_concepts : Specification
     }
 
     [Fact]
-    public void greater_concept_should_have_higher_order()
+    public void should_order_greater_concept_higher()
     {
         var conceptA = new IntConcept(42);
         var conceptB = new IntConcept(24);
@@ -38,7 +38,7 @@ public class when_comparing_concepts : Specification
     }
 
     [Fact]
-    public void lesser_concept_should_have_lower_order()
+    public void should_order_lesser_concept_lower()
     {
         var conceptA = new IntConcept(24);
         var conceptB = new IntConcept(42);
@@ -48,7 +48,7 @@ public class when_comparing_concepts : Specification
     }
 
     [Fact]
-    public void equal_concepts_should_have_same_hash_code()
+    public void should_give_equal_concepts_same_hash_code()
     {
         var conceptA = new IntConcept(42);
         var conceptB = new IntConcept(42);
@@ -57,7 +57,7 @@ public class when_comparing_concepts : Specification
     }
 
     [Fact]
-    public void unequal_concepts_should_have_different_hash_codes()
+    public void should_give_unequal_concepts_different_hash_codes()
     {
         var conceptA = new IntConcept(42);
         var conceptB = new IntConcept(24);

--- a/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/given/converter_for_converting_from_json.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/given/converter_for_converting_from_json.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Text;
-using System.Text.Json;
 using Cratis.Concepts;
 
 namespace Cratis.Json.for_ConceptAsJsonConverter.given;
@@ -15,22 +13,12 @@ public abstract class converter_for_converting_from_json<TConcept, TUnderlying> 
 
     protected abstract TUnderlying InputValue { get; }
     protected abstract string FormattedInput { get; }
+    protected Type ConceptType => typeof(TConcept);
 
     void Establish()
     {
         converter = new();
         input = InputValue;
-    }
-
-    void Because()
-    {
-        var fullJson = $"{{ \"prop\": {FormattedInput} }}";
-
-        Utf8JsonReader reader = new(Encoding.UTF8.GetBytes(fullJson).AsSpan());
-        reader.Read();  // Start object
-        reader.Read();  // Property
-        reader.Read();  // Value
-        result = converter.Read(ref reader, typeof(TConcept), default);
     }
 
     protected void ShouldConvertToCorrectConcept() => result.GetConceptValue().ShouldEqual(input);

--- a/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/given/converter_for_converting_to_json.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/given/converter_for_converting_to_json.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Text;
 using System.Text.Json;
 
 namespace Cratis.Json.for_ConceptAsJsonConverter.given;
@@ -11,8 +10,8 @@ public abstract class converter_for_converting_to_json<TConcept, TUnderlying> : 
     protected ConceptAsJsonConverter<TConcept> converter;
     protected TConcept input;
     protected string result;
-    MemoryStream stream;
-    Utf8JsonWriter writer;
+    protected MemoryStream stream;
+    protected Utf8JsonWriter writer;
 
     protected abstract TUnderlying Expected { get; }
     protected abstract string FormattedExpected { get; }
@@ -26,13 +25,6 @@ public abstract class converter_for_converting_to_json<TConcept, TUnderlying> : 
                     .Invoke([Expected]);
         stream = new();
         writer = new(stream);
-    }
-
-    void Because()
-    {
-        converter.Write(writer, input, default);
-        writer.Flush();
-        result = Encoding.UTF8.GetString(stream.ToArray());
     }
 
     protected void ShouldConvertToJson() => result.ShouldEqual(FormattedExpected);

--- a/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_boolean_concept_from_json.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_boolean_concept_from_json.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+using System.Text.Json;
+
 namespace Cratis.Json.for_ConceptAsJsonConverter;
 
 public class when_converting_boolean_concept_from_json : given.converter_for_converting_from_json<BooleanConcept, bool>
@@ -8,6 +11,17 @@ public class when_converting_boolean_concept_from_json : given.converter_for_con
     protected override bool InputValue => true;
 
     protected override string FormattedInput => "true";
+
+    void Because()
+    {
+        var fullJson = $"{{ \"prop\": {FormattedInput} }}";
+
+        Utf8JsonReader reader = new(Encoding.UTF8.GetBytes(fullJson).AsSpan());
+        reader.Read();  // Start object
+        reader.Read();  // Property
+        reader.Read();  // Value
+        result = converter.Read(ref reader, ConceptType, default);
+    }
 
     [Fact] void should_convert_to_correct_bool() => ShouldConvertToCorrectConcept();
 }

--- a/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_boolean_concept_to_json.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_boolean_concept_to_json.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+
 namespace Cratis.Json.for_ConceptAsJsonConverter;
 
 public class when_converting_boolean_concept_to_json : given.converter_for_converting_to_json<BooleanConcept, bool>
@@ -8,6 +10,13 @@ public class when_converting_boolean_concept_to_json : given.converter_for_conve
     protected override bool Expected => true;
 
     protected override string FormattedExpected => "true";
+
+    void Because()
+    {
+        converter.Write(writer, input, default);
+        writer.Flush();
+        result = Encoding.UTF8.GetString(stream.ToArray());
+    }
 
     [Fact] void should_convert_to_correct_guid() => ShouldConvertToJson();
 }

--- a/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_byte_concept_from_json.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_byte_concept_from_json.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+using System.Text.Json;
+
 namespace Cratis.Json.for_ConceptAsJsonConverter;
 
 public class when_converting_byte_concept_from_json : given.converter_for_converting_from_json<ByteConcept, byte>
@@ -8,6 +11,17 @@ public class when_converting_byte_concept_from_json : given.converter_for_conver
     protected override byte InputValue => 42;
 
     protected override string FormattedInput => "42";
+
+    void Because()
+    {
+        var fullJson = $"{{ \"prop\": {FormattedInput} }}";
+
+        Utf8JsonReader reader = new(Encoding.UTF8.GetBytes(fullJson).AsSpan());
+        reader.Read();  // Start object
+        reader.Read();  // Property
+        reader.Read();  // Value
+        result = converter.Read(ref reader, ConceptType, default);
+    }
 
     [Fact] void should_convert_to_correct_byte() => ShouldConvertToCorrectConcept();
 }

--- a/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_byte_concept_to_json.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_byte_concept_to_json.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+
 namespace Cratis.Json.for_ConceptAsJsonConverter;
 
 public class when_converting_byte_concept_to_json : given.converter_for_converting_to_json<ByteConcept, byte>
@@ -8,6 +10,13 @@ public class when_converting_byte_concept_to_json : given.converter_for_converti
     protected override byte Expected => 42;
 
     protected override string FormattedExpected => "42";
+
+    void Because()
+    {
+        converter.Write(writer, input, default);
+        writer.Flush();
+        result = Encoding.UTF8.GetString(stream.ToArray());
+    }
 
     [Fact] void should_convert_to_correct_byte() => ShouldConvertToJson();
 }

--- a/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_date_only_concept_from_json.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_date_only_concept_from_json.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+using System.Text.Json;
+
 namespace Cratis.Json.for_ConceptAsJsonConverter;
 
 public class when_converting_date_only_concept_from_json : given.converter_for_converting_from_json<DateOnlyConcept, DateOnly>
@@ -8,6 +11,17 @@ public class when_converting_date_only_concept_from_json : given.converter_for_c
     protected override DateOnly InputValue => DateOnly.FromDateTime(DateTime.UtcNow);
 
     protected override string FormattedInput => $"\"{input:O}\"";
+
+    void Because()
+    {
+        var fullJson = $"{{ \"prop\": {FormattedInput} }}";
+
+        Utf8JsonReader reader = new(Encoding.UTF8.GetBytes(fullJson).AsSpan());
+        reader.Read();  // Start object
+        reader.Read();  // Property
+        reader.Read();  // Value
+        result = converter.Read(ref reader, ConceptType, default);
+    }
 
     [Fact] void should_convert_to_correct_date_only() => ShouldConvertToCorrectConcept();
 }

--- a/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_date_only_concept_to_json.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_date_only_concept_to_json.cs
@@ -1,12 +1,21 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+
 namespace Cratis.Json.for_ConceptAsJsonConverter;
 
 public class when_converting_date_only_concept_to_json : given.converter_for_converting_to_json<DateOnlyConcept, DateOnly>
 {
     protected override DateOnly Expected => DateOnly.FromDateTime(DateTime.UtcNow);
     protected override string FormattedExpected => $"\"{input.Value:O}\"";
+
+    void Because()
+    {
+        converter.Write(writer, input, default);
+        writer.Flush();
+        result = Encoding.UTF8.GetString(stream.ToArray());
+    }
 
     [Fact] void should_convert_to_correct_date_only() => ShouldConvertToJson();
 }

--- a/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_decimal_concept_from_json.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_decimal_concept_from_json.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+using System.Text.Json;
+
 namespace Cratis.Json.for_ConceptAsJsonConverter;
 
 public class when_converting_decimal_concept_from_json : given.converter_for_converting_from_json<DecimalConcept, decimal>
@@ -8,6 +11,17 @@ public class when_converting_decimal_concept_from_json : given.converter_for_con
     protected override decimal InputValue => 42.43M;
 
     protected override string FormattedInput => "42.43";
+
+    void Because()
+    {
+        var fullJson = $"{{ \"prop\": {FormattedInput} }}";
+
+        Utf8JsonReader reader = new(Encoding.UTF8.GetBytes(fullJson).AsSpan());
+        reader.Read();  // Start object
+        reader.Read();  // Property
+        reader.Read();  // Value
+        result = converter.Read(ref reader, ConceptType, default);
+    }
 
     [Fact] void should_convert_to_correct_decimal() => ShouldConvertToCorrectConcept();
 }

--- a/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_decimal_concept_to_json.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_decimal_concept_to_json.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+
 namespace Cratis.Json.for_ConceptAsJsonConverter;
 
 public class when_converting_decimal_concept_to_json : given.converter_for_converting_to_json<DecimalConcept, decimal>
@@ -8,6 +10,13 @@ public class when_converting_decimal_concept_to_json : given.converter_for_conve
     protected override decimal Expected => 42.43M;
 
     protected override string FormattedExpected => "42.43";
+
+    void Because()
+    {
+        converter.Write(writer, input, default);
+        writer.Flush();
+        result = Encoding.UTF8.GetString(stream.ToArray());
+    }
 
     [Fact] void should_convert_to_correct_decimal() => ShouldConvertToJson();
 }

--- a/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_double_concept_from_json.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_double_concept_from_json.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+using System.Text.Json;
+
 namespace Cratis.Json.for_ConceptAsJsonConverter;
 
 public class when_converting_double_concept_from_json : given.converter_for_converting_from_json<DoubleConcept, double>
@@ -8,6 +11,17 @@ public class when_converting_double_concept_from_json : given.converter_for_conv
     protected override double InputValue => 42.43;
 
     protected override string FormattedInput => "42.43";
+
+    void Because()
+    {
+        var fullJson = $"{{ \"prop\": {FormattedInput} }}";
+
+        Utf8JsonReader reader = new(Encoding.UTF8.GetBytes(fullJson).AsSpan());
+        reader.Read();  // Start object
+        reader.Read();  // Property
+        reader.Read();  // Value
+        result = converter.Read(ref reader, ConceptType, default);
+    }
 
     [Fact] void should_convert_to_correct_double() => ShouldConvertToCorrectConcept();
 }

--- a/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_double_concept_to_json.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_double_concept_to_json.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+
 namespace Cratis.Json.for_ConceptAsJsonConverter;
 
 public class when_converting_double_concept_to_json : given.converter_for_converting_to_json<DoubleConcept, double>
@@ -8,6 +10,13 @@ public class when_converting_double_concept_to_json : given.converter_for_conver
     protected override double Expected => 42.43;
 
     protected override string FormattedExpected => "42.43";
+
+    void Because()
+    {
+        converter.Write(writer, input, default);
+        writer.Flush();
+        result = Encoding.UTF8.GetString(stream.ToArray());
+    }
 
     [Fact] void should_convert_to_correct_guid() => ShouldConvertToJson();
 }

--- a/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_guid_concept_from_json.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_guid_concept_from_json.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+using System.Text.Json;
+
 namespace Cratis.Json.for_ConceptAsJsonConverter;
 
 public class when_converting_guid_concept_from_json : given.converter_for_converting_from_json<GuidConcept, Guid>
@@ -8,6 +11,17 @@ public class when_converting_guid_concept_from_json : given.converter_for_conver
     protected override Guid InputValue => Guid.NewGuid();
 
     protected override string FormattedInput => $"\"{input}\"";
+
+    void Because()
+    {
+        var fullJson = $"{{ \"prop\": {FormattedInput} }}";
+
+        Utf8JsonReader reader = new(Encoding.UTF8.GetBytes(fullJson).AsSpan());
+        reader.Read();  // Start object
+        reader.Read();  // Property
+        reader.Read();  // Value
+        result = converter.Read(ref reader, ConceptType, default);
+    }
 
     [Fact] void should_convert_to_correct_guid() => ShouldConvertToCorrectConcept();
 }

--- a/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_guid_concept_to_json.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_guid_concept_to_json.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+
 namespace Cratis.Json.for_ConceptAsJsonConverter;
 
 public class when_converting_guid_concept_to_json : given.converter_for_converting_to_json<GuidConcept, Guid>
@@ -8,6 +10,13 @@ public class when_converting_guid_concept_to_json : given.converter_for_converti
     protected override Guid Expected => Guid.NewGuid();
 
     protected override string FormattedExpected => $"\"{input.Value}\"";
+
+    void Because()
+    {
+        converter.Write(writer, input, default);
+        writer.Flush();
+        result = Encoding.UTF8.GetString(stream.ToArray());
+    }
 
     [Fact] void should_convert_to_correct_guid() => ShouldConvertToJson();
 }

--- a/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_int_concept_from_json.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_int_concept_from_json.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+using System.Text.Json;
+
 namespace Cratis.Json.for_ConceptAsJsonConverter;
 
 public class when_converting_int_concept_from_json : given.converter_for_converting_from_json<IntConcept, int>
@@ -8,6 +11,17 @@ public class when_converting_int_concept_from_json : given.converter_for_convert
     protected override int InputValue => 42;
 
     protected override string FormattedInput => "42";
+
+    void Because()
+    {
+        var fullJson = $"{{ \"prop\": {FormattedInput} }}";
+
+        Utf8JsonReader reader = new(Encoding.UTF8.GetBytes(fullJson).AsSpan());
+        reader.Read();  // Start object
+        reader.Read();  // Property
+        reader.Read();  // Value
+        result = converter.Read(ref reader, ConceptType, default);
+    }
 
     [Fact] void should_convert_to_correct_int() => ShouldConvertToCorrectConcept();
 }

--- a/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_int_concept_to_json.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_int_concept_to_json.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+
 namespace Cratis.Json.for_ConceptAsJsonConverter;
 
 public class when_converting_int_concept_to_json : given.converter_for_converting_to_json<IntConcept, int>
@@ -8,6 +10,13 @@ public class when_converting_int_concept_to_json : given.converter_for_convertin
     protected override int Expected => 42;
 
     protected override string FormattedExpected => "42";
+
+    void Because()
+    {
+        converter.Write(writer, input, default);
+        writer.Flush();
+        result = Encoding.UTF8.GetString(stream.ToArray());
+    }
 
     [Fact] void should_convert_to_correct_int() => ShouldConvertToJson();
 }

--- a/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_long_concept_from_json.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_long_concept_from_json.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+using System.Text.Json;
+
 namespace Cratis.Json.for_ConceptAsJsonConverter;
 
 public class when_converting_long_concept_from_json : given.converter_for_converting_from_json<LongConcept, long>
@@ -8,6 +11,17 @@ public class when_converting_long_concept_from_json : given.converter_for_conver
     protected override long InputValue => 42;
 
     protected override string FormattedInput => "42";
+
+    void Because()
+    {
+        var fullJson = $"{{ \"prop\": {FormattedInput} }}";
+
+        Utf8JsonReader reader = new(Encoding.UTF8.GetBytes(fullJson).AsSpan());
+        reader.Read();  // Start object
+        reader.Read();  // Property
+        reader.Read();  // Value
+        result = converter.Read(ref reader, ConceptType, default);
+    }
 
     [Fact] void should_convert_to_correct_long() => ShouldConvertToCorrectConcept();
 }

--- a/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_long_concept_to_json.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_long_concept_to_json.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+
 namespace Cratis.Json.for_ConceptAsJsonConverter;
 
 public class when_converting_long_concept_to_json : given.converter_for_converting_to_json<LongConcept, long>
@@ -8,6 +10,13 @@ public class when_converting_long_concept_to_json : given.converter_for_converti
     protected override long Expected => 42;
 
     protected override string FormattedExpected => "42";
+
+    void Because()
+    {
+        converter.Write(writer, input, default);
+        writer.Flush();
+        result = Encoding.UTF8.GetString(stream.ToArray());
+    }
 
     [Fact] void should_convert_to_correct_long() => ShouldConvertToJson();
 }

--- a/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_sbyte_concept_from_json.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_sbyte_concept_from_json.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+using System.Text.Json;
+
 namespace Cratis.Json.for_ConceptAsJsonConverter;
 
 public class when_converting_sbyte_concept_from_json : given.converter_for_converting_from_json<SByteConcept, sbyte>
@@ -8,6 +11,17 @@ public class when_converting_sbyte_concept_from_json : given.converter_for_conve
     protected override sbyte InputValue => 42;
 
     protected override string FormattedInput => "42";
+
+    void Because()
+    {
+        var fullJson = $"{{ \"prop\": {FormattedInput} }}";
+
+        Utf8JsonReader reader = new(Encoding.UTF8.GetBytes(fullJson).AsSpan());
+        reader.Read();  // Start object
+        reader.Read();  // Property
+        reader.Read();  // Value
+        result = converter.Read(ref reader, ConceptType, default);
+    }
 
     [Fact] void should_convert_to_correct_sbyte() => ShouldConvertToCorrectConcept();
 }

--- a/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_sbyte_concept_to_json.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_sbyte_concept_to_json.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+
 namespace Cratis.Json.for_ConceptAsJsonConverter;
 
 public class when_converting_sbyte_concept_to_json : given.converter_for_converting_to_json<SByteConcept, sbyte>
@@ -8,6 +10,13 @@ public class when_converting_sbyte_concept_to_json : given.converter_for_convert
     protected override sbyte Expected => 42;
 
     protected override string FormattedExpected => "42";
+
+    void Because()
+    {
+        converter.Write(writer, input, default);
+        writer.Flush();
+        result = Encoding.UTF8.GetString(stream.ToArray());
+    }
 
     [Fact] void should_convert_to_correct_byte() => ShouldConvertToJson();
 }

--- a/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_short_concept_from_json.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_short_concept_from_json.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+using System.Text.Json;
+
 namespace Cratis.Json.for_ConceptAsJsonConverter;
 
 public class when_converting_short_concept_from_json : given.converter_for_converting_from_json<ShortConcept, short>
@@ -8,6 +11,17 @@ public class when_converting_short_concept_from_json : given.converter_for_conve
     protected override short InputValue => 42;
 
     protected override string FormattedInput => "42";
+
+    void Because()
+    {
+        var fullJson = $"{{ \"prop\": {FormattedInput} }}";
+
+        Utf8JsonReader reader = new(Encoding.UTF8.GetBytes(fullJson).AsSpan());
+        reader.Read();  // Start object
+        reader.Read();  // Property
+        reader.Read();  // Value
+        result = converter.Read(ref reader, ConceptType, default);
+    }
 
     [Fact] void should_convert_to_correct_short() => ShouldConvertToCorrectConcept();
 }

--- a/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_short_concept_to_json.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_short_concept_to_json.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+
 namespace Cratis.Json.for_ConceptAsJsonConverter;
 
 public class when_converting_short_concept_to_json : given.converter_for_converting_to_json<ShortConcept, short>
@@ -8,6 +10,13 @@ public class when_converting_short_concept_to_json : given.converter_for_convert
     protected override short Expected => 42;
 
     protected override string FormattedExpected => "42";
+
+    void Because()
+    {
+        converter.Write(writer, input, default);
+        writer.Flush();
+        result = Encoding.UTF8.GetString(stream.ToArray());
+    }
 
     [Fact] void should_convert_to_correct_short() => ShouldConvertToJson();
 }

--- a/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_time_only_concept_from_json.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_time_only_concept_from_json.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+using System.Text.Json;
+
 namespace Cratis.Json.for_ConceptAsJsonConverter;
 
 public class when_converting_time_only_concept_from_json : given.converter_for_converting_from_json<TimeOnlyConcept, TimeOnly>
@@ -8,6 +11,17 @@ public class when_converting_time_only_concept_from_json : given.converter_for_c
     protected override TimeOnly InputValue => TimeOnly.FromDateTime(DateTime.UtcNow);
 
     protected override string FormattedInput => $"\"{input:O}\"";
+
+    void Because()
+    {
+        var fullJson = $"{{ \"prop\": {FormattedInput} }}";
+
+        Utf8JsonReader reader = new(Encoding.UTF8.GetBytes(fullJson).AsSpan());
+        reader.Read();  // Start object
+        reader.Read();  // Property
+        reader.Read();  // Value
+        result = converter.Read(ref reader, ConceptType, default);
+    }
 
     [Fact] void should_convert_to_correct_time_only() => ShouldConvertToCorrectConcept();
 }

--- a/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_time_only_concept_to_json.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_time_only_concept_to_json.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+
 namespace Cratis.Json.for_ConceptAsJsonConverter;
 
 public class when_converting_time_only_concept_to_json : given.converter_for_converting_to_json<TimeOnlyConcept, TimeOnly>
@@ -8,6 +10,13 @@ public class when_converting_time_only_concept_to_json : given.converter_for_con
     protected override TimeOnly Expected => TimeOnly.FromDateTime(DateTime.UtcNow);
 
     protected override string FormattedExpected => $"\"{input.Value:O}\"";
+
+    void Because()
+    {
+        converter.Write(writer, input, default);
+        writer.Flush();
+        result = Encoding.UTF8.GetString(stream.ToArray());
+    }
 
     [Fact] void should_convert_to_correct_time_only() => ShouldConvertToJson();
 }

--- a/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_uint_concept_from_json.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_uint_concept_from_json.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+using System.Text.Json;
+
 namespace Cratis.Json.for_ConceptAsJsonConverter;
 
 public class when_converting_uint_concept_from_json : given.converter_for_converting_from_json<UIntConcept, uint>
@@ -8,6 +11,17 @@ public class when_converting_uint_concept_from_json : given.converter_for_conver
     protected override uint InputValue => 42;
 
     protected override string FormattedInput => "42";
+
+    void Because()
+    {
+        var fullJson = $"{{ \"prop\": {FormattedInput} }}";
+
+        Utf8JsonReader reader = new(Encoding.UTF8.GetBytes(fullJson).AsSpan());
+        reader.Read();  // Start object
+        reader.Read();  // Property
+        reader.Read();  // Value
+        result = converter.Read(ref reader, ConceptType, default);
+    }
 
     [Fact] void should_convert_to_correct_uint() => ShouldConvertToCorrectConcept();
 }

--- a/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_uint_concept_to_json.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_uint_concept_to_json.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+
 namespace Cratis.Json.for_ConceptAsJsonConverter;
 
 public class when_converting_uint_concept_to_json : given.converter_for_converting_to_json<UIntConcept, uint>
@@ -8,6 +10,13 @@ public class when_converting_uint_concept_to_json : given.converter_for_converti
     protected override uint Expected => 42;
 
     protected override string FormattedExpected => "42";
+
+    void Because()
+    {
+        converter.Write(writer, input, default);
+        writer.Flush();
+        result = Encoding.UTF8.GetString(stream.ToArray());
+    }
 
     [Fact] void should_convert_to_correct_uint() => ShouldConvertToJson();
 }

--- a/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_ulong_concept_from_json.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_ulong_concept_from_json.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+using System.Text.Json;
+
 namespace Cratis.Json.for_ConceptAsJsonConverter;
 
 public class when_converting_ulong_concept_from_json : given.converter_for_converting_from_json<ULongConcept, ulong>
@@ -8,6 +11,17 @@ public class when_converting_ulong_concept_from_json : given.converter_for_conve
     protected override ulong InputValue => 42;
 
     protected override string FormattedInput => "42";
+
+    void Because()
+    {
+        var fullJson = $"{{ \"prop\": {FormattedInput} }}";
+
+        Utf8JsonReader reader = new(Encoding.UTF8.GetBytes(fullJson).AsSpan());
+        reader.Read();  // Start object
+        reader.Read();  // Property
+        reader.Read();  // Value
+        result = converter.Read(ref reader, ConceptType, default);
+    }
 
     [Fact] void should_convert_to_correct_ulong() => ShouldConvertToCorrectConcept();
 }

--- a/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_ulong_concept_to_json.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_ulong_concept_to_json.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+
 namespace Cratis.Json.for_ConceptAsJsonConverter;
 
 public class when_converting_ulong_concept_to_json : given.converter_for_converting_to_json<ULongConcept, ulong>
@@ -8,6 +10,13 @@ public class when_converting_ulong_concept_to_json : given.converter_for_convert
     protected override ulong Expected => 42;
 
     protected override string FormattedExpected => "42";
+
+    void Because()
+    {
+        converter.Write(writer, input, default);
+        writer.Flush();
+        result = Encoding.UTF8.GetString(stream.ToArray());
+    }
 
     [Fact] void should_convert_to_correct_ulong() => ShouldConvertToJson();
 }

--- a/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_ushort_concept_from_json.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_ushort_concept_from_json.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+using System.Text.Json;
+
 namespace Cratis.Json.for_ConceptAsJsonConverter;
 
 public class when_converting_ushort_concept_from_json : given.converter_for_converting_from_json<UShortConcept, ushort>
@@ -8,6 +11,17 @@ public class when_converting_ushort_concept_from_json : given.converter_for_conv
     protected override ushort InputValue => 42;
 
     protected override string FormattedInput => "42";
+
+    void Because()
+    {
+        var fullJson = $"{{ \"prop\": {FormattedInput} }}";
+
+        Utf8JsonReader reader = new(Encoding.UTF8.GetBytes(fullJson).AsSpan());
+        reader.Read();  // Start object
+        reader.Read();  // Property
+        reader.Read();  // Value
+        result = converter.Read(ref reader, ConceptType, default);
+    }
 
     [Fact] void should_convert_to_correct_ushort() => ShouldConvertToCorrectConcept();
 }

--- a/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_ushort_concept_to_json.cs
+++ b/Source/DotNET/Fundamentals.Specs/Json/for_ConceptAsJsonConverter/when_converting_ushort_concept_to_json.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+
 namespace Cratis.Json.for_ConceptAsJsonConverter;
 
 public class when_converting_ushort_concept_to_json : given.converter_for_converting_to_json<UShortConcept, ushort>
@@ -8,6 +10,13 @@ public class when_converting_ushort_concept_to_json : given.converter_for_conver
     protected override ushort Expected => 42;
 
     protected override string FormattedExpected => "42";
+
+    void Because()
+    {
+        converter.Write(writer, input, default);
+        writer.Flush();
+        result = Encoding.UTF8.GetString(stream.ToArray());
+    }
 
     [Fact] void should_convert_to_correct_ushort() => ShouldConvertToJson();
 }

--- a/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_getting_derived_type_without_any_matching_derived_type_identifier.cs
+++ b/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_getting_derived_type_without_any_matching_derived_type_identifier.cs
@@ -8,7 +8,7 @@ public class when_getting_derived_type_without_any_matching_derived_type_identif
     interface ITargetType;
 
     [DerivedType("known-type")]
-    record DerivedType : ITargetType { }
+    record DerivedType : ITargetType;
 
     DerivedTypes derived_types;
     Exception result;

--- a/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_getting_known_derived_type_that_matches.cs
+++ b/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_getting_known_derived_type_that_matches.cs
@@ -8,7 +8,7 @@ public class when_getting_known_derived_type_that_matches : given.derived_types
     interface ITargetType;
 
     [DerivedType("known-type")]
-    record DerivedType : ITargetType { }
+    record DerivedType : ITargetType;
 
     DerivedTypes derived_types;
     Type result;

--- a/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_getting_target_type_for_known_derived_type.cs
+++ b/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_getting_target_type_for_known_derived_type.cs
@@ -8,7 +8,7 @@ public class when_getting_target_type_for_known_derived_type : given.derived_typ
     interface ITargetType;
 
     [DerivedType("known-type")]
-    record DerivedType : ITargetType { }
+    record DerivedType : ITargetType;
 
     DerivedTypes derived_types;
     Type result;

--- a/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_initializing_with_multiple_types_having_same_identifier.cs
+++ b/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_initializing_with_multiple_types_having_same_identifier.cs
@@ -8,10 +8,10 @@ public class when_initializing_with_multiple_types_having_same_identifier : give
     interface ITargetType;
 
     [DerivedType("first-type")]
-    record FirstDerivedType : ITargetType { }
+    record FirstDerivedType : ITargetType;
 
     [DerivedType("first-type")]
-    record SecondDerivedType : ITargetType { }
+    record SecondDerivedType : ITargetType;
 
     Exception result;
 

--- a/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_initializing_with_type_with_multiple_target_types.cs
+++ b/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_initializing_with_type_with_multiple_target_types.cs
@@ -9,7 +9,7 @@ public class when_initializing_with_type_with_multiple_target_types : given.deri
     interface ISecond;
 
     [DerivedType("known-type")]
-    record DerivedType : IFirst, ISecond { }
+    record DerivedType : IFirst, ISecond;
 
     Exception result;
 

--- a/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_initializing_with_type_with_target_type_but_no_target_types_implemented.cs
+++ b/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_initializing_with_type_with_target_type_but_no_target_types_implemented.cs
@@ -8,7 +8,7 @@ public class when_initializing_with_type_with_target_type_but_no_target_types_im
     interface ITarget;
 
     [DerivedType("known-type", typeof(ITarget))]
-    record DerivedType { }
+    record DerivedType;
 
     Exception result;
 

--- a/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_initializing_with_type_with_target_type_mismatch.cs
+++ b/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_initializing_with_type_with_target_type_mismatch.cs
@@ -9,7 +9,7 @@ public class when_initializing_with_type_with_target_type_mismatch : given.deriv
     interface ISecond;
 
     [DerivedType("known-type", typeof(ISecond))]
-    record DerivedType : IFirst { }
+    record DerivedType : IFirst;
 
     Exception result;
 

--- a/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_initializing_without_target_type.cs
+++ b/Source/DotNET/Fundamentals.Specs/Serialization/for_DerivedTypes/when_initializing_without_target_type.cs
@@ -6,7 +6,7 @@ namespace Cratis.Serialization.for_DerivedTypes;
 public class when_initializing_without_target_type : given.derived_types
 {
     [DerivedType("known-type")]
-    record DerivedType { }
+    record DerivedType;
 
     Exception result;
 

--- a/Source/JavaScript/Fields.ts
+++ b/Source/JavaScript/Fields.ts
@@ -4,6 +4,7 @@
 import './reflection';
 import { Constructor } from './Constructor';
 import { Field } from './Field';
+import { getOwnDecoratorFieldsForType } from './fieldDecoratorMetadata';
 
 /**
  * Represents a system working with fields on types.
@@ -19,9 +20,10 @@ export class Fields {
     }
 
     static getFieldsForType(target: Constructor): Field[] {
-        // Fields are stored as own-metadata per type, so a derived type only carries the fields it
-        // declares itself. Walk the prototype (inheritance) chain and merge every ancestor's fields so
-        // that deserializing a derived type also populates the fields inherited from its base types.
+        // Fields are stored as legacy own metadata on the constructor or as standard own metadata on
+        // its Symbol.metadata object, so a derived type only carries the fields it declares itself.
+        // Walk the prototype (inheritance) chain and merge every ancestor's fields so that deserializing
+        // a derived type also populates the fields inherited from its base types.
         // Process from the base type down to the target so a derived field overrides a base field of the
         // same name.
         const chain: Constructor[] = [];
@@ -39,6 +41,10 @@ export class Fields {
                 for (const [name, field] of fieldsMap.entries()) {
                     fieldsByName.set(name, field);
                 }
+            }
+
+            for (const field of getOwnDecoratorFieldsForType(type)) {
+                fieldsByName.set(field.name, field);
             }
         }
 

--- a/Source/JavaScript/StandardClassDecoratorContext.ts
+++ b/Source/JavaScript/StandardClassDecoratorContext.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Constructor } from './Constructor';
+
+/**
+ * Represents the standard decorator context used for a class.
+ */
+export type StandardClassDecoratorContext<Target extends Constructor> = {
+    readonly kind: 'class';
+    readonly name: string | undefined;
+    readonly metadata: Record<PropertyKey, unknown> | undefined;
+    addInitializer(initializer: (this: Target) => void): void;
+};

--- a/Source/JavaScript/StandardFieldDecoratorContext.ts
+++ b/Source/JavaScript/StandardFieldDecoratorContext.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+ * Represents the standard decorator context used for a class field.
+ */
+export type StandardFieldDecoratorContext = {
+    readonly kind: 'field';
+    readonly name: string | symbol;
+    readonly static: boolean;
+    readonly private: boolean;
+    readonly metadata: Record<PropertyKey, unknown> | undefined;
+};

--- a/Source/JavaScript/derivedTypeDecorator.ts
+++ b/Source/JavaScript/derivedTypeDecorator.ts
@@ -4,12 +4,27 @@
 import './reflection';
 import { Constructor } from './Constructor';
 import { DerivedType } from './DerivedType';
-
-
-/* eslint-disable @typescript-eslint/no-explicit-any */
+import { StandardClassDecoratorContext } from './StandardClassDecoratorContext';
 
 export function derivedType(identifier: string, targetType?: Constructor) {
-    return function (target: any) {
+    function decorator<Target extends Constructor>(target: Target): void;
+    function decorator<Target extends Constructor>(target: Target, context: StandardClassDecoratorContext<Target>): void;
+    function decorator(target: Constructor, context?: StandardClassDecoratorContext<Constructor>): void {
+        if (typeof target !== 'function') throw new TypeError('@derivedType can only decorate classes');
+        if (context && context.kind !== 'class') throw new TypeError('@derivedType can only decorate classes');
+        if (context && typeof context.addInitializer !== 'function') throw new TypeError('@derivedType requires a standard class decorator context');
+
+        if (context) {
+            context.addInitializer(function (this: Constructor): void {
+                register(this);
+            });
+            return;
+        }
+
+        register(target);
+    }
+
+    function register(target: Constructor): void {
         DerivedType.set(target, identifier, targetType);
 
         // Auto-register with every class in the prototype chain so that JsonSerializer
@@ -20,5 +35,7 @@ export function derivedType(identifier: string, targetType?: Constructor) {
             DerivedType.set(target, identifier, proto.constructor);
             proto = Object.getPrototypeOf(proto);
         }
-    };
+    }
+
+    return decorator;
 }

--- a/Source/JavaScript/fieldDecorator.ts
+++ b/Source/JavaScript/fieldDecorator.ts
@@ -2,9 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { Constructor } from './Constructor';
+import { Field } from './Field';
 import { Fields } from './Fields';
-
-/* eslint-disable @typescript-eslint/no-explicit-any */
+import { addFieldToDecoratorMetadata } from './fieldDecoratorMetadata';
+import { StandardFieldDecoratorContext } from './StandardFieldDecoratorContext';
 
 type fieldOptions = {
     enumerable?: boolean;
@@ -21,7 +22,37 @@ export function field(targetType: Constructor, enumerableOrOptions?: boolean | f
     const actualDerivatives = isFieldOptions(enumerableOrOptions) ? (enumerableOrOptions.derivatives || []) : (derivatives || []);
     const actualGenericArguments = isFieldOptions(enumerableOrOptions) ? (enumerableOrOptions.genericArguments || []) : (genericArguments || []);
 
-    return function (target: any, propertyKey: string) {
-        Fields.addFieldToType(target.constructor, propertyKey, targetType, enumerable, actualDerivatives, actualGenericArguments);
-    };
+    function decorator(target: object, propertyKey: string): void;
+    function decorator(initialValue: undefined, context: StandardFieldDecoratorContext): void;
+    function decorator(targetOrInitialValue: object | undefined, propertyKeyOrContext: string | symbol | StandardFieldDecoratorContext): void {
+        if (typeof propertyKeyOrContext === 'object' && propertyKeyOrContext !== null) {
+            if (targetOrInitialValue !== undefined) throw new TypeError('@field received an invalid standard field value');
+            addStandardField(propertyKeyOrContext);
+            return;
+        }
+
+        addLegacyField(targetOrInitialValue, propertyKeyOrContext);
+    }
+
+    function addStandardField(context: StandardFieldDecoratorContext): void {
+        if (context.kind !== 'field') throw new TypeError('@field can only decorate fields');
+        if (context.static) throw new TypeError('@field cannot decorate static fields');
+        if (context.private) throw new TypeError('@field cannot decorate private fields');
+        if (typeof context.name !== 'string') throw new TypeError('@field cannot decorate symbol-named fields');
+        if (!context.metadata) throw new TypeError('@field requires standard decorator metadata support');
+
+        addFieldToDecoratorMetadata(
+            context.metadata,
+            new Field(context.name, targetType, enumerable, actualDerivatives, actualGenericArguments));
+    }
+
+    function addLegacyField(target: object | undefined, propertyKey: string | symbol): void {
+        if (typeof propertyKey === 'symbol') throw new TypeError('@field cannot decorate symbol-named fields');
+        if (typeof propertyKey !== 'string') throw new TypeError('@field received an invalid legacy decorator invocation');
+        if (!target || typeof target === 'function') throw new TypeError('@field cannot decorate static fields');
+
+        Fields.addFieldToType(target.constructor as Constructor, propertyKey, targetType, enumerable, actualDerivatives, actualGenericArguments);
+    }
+
+    return decorator;
 }

--- a/Source/JavaScript/fieldDecoratorMetadata.ts
+++ b/Source/JavaScript/fieldDecoratorMetadata.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import './reflection';
+import { Constructor } from './Constructor';
+import { Field } from './Field';
+
+const fieldsMetadataKey = 'fields';
+
+/**
+ * Adds a field to the metadata object supplied to a standard decorator.
+ * @param metadata The class metadata object supplied by the decorator runtime.
+ * @param field The field to add.
+ */
+export function addFieldToDecoratorMetadata(metadata: Record<PropertyKey, unknown>, field: Field): void {
+    const fields = Reflect.getOwnMetadata(fieldsMetadataKey, metadata) as Map<string, Field> | undefined ?? new Map<string, Field>();
+    fields.set(field.name, field);
+    Reflect.defineMetadata(fieldsMetadataKey, fields, metadata);
+}
+
+/**
+ * Gets the fields stored in the standard decorator metadata owned by a type.
+ * @param target The type to read metadata from.
+ * @returns The fields declared by the type through standard decorators.
+ */
+export function getOwnDecoratorFieldsForType(target: Constructor): Field[] {
+    if (!Object.prototype.hasOwnProperty.call(target, Symbol.metadata)) return [];
+
+    const metadata = (target as Constructor & { [Symbol.metadata]?: Record<PropertyKey, unknown> | null })[Symbol.metadata];
+    if (!metadata) return [];
+
+    const fields = Reflect.getOwnMetadata(fieldsMetadataKey, metadata) as Map<string, Field> | undefined;
+    return fields ? [...fields.values()] : [];
+}

--- a/Source/JavaScript/fieldDecoratorMetadata.ts
+++ b/Source/JavaScript/fieldDecoratorMetadata.ts
@@ -5,7 +5,7 @@ import './reflection';
 import { Constructor } from './Constructor';
 import { Field } from './Field';
 
-const fieldsMetadataKey = 'fields';
+const fieldsMetadataKey = Symbol.for('@cratis/fundamentals.fields');
 
 /**
  * Adds a field to the metadata object supplied to a standard decorator.

--- a/Source/JavaScript/for_JsonSerializer/when_metadata_is_written_by_another_copy_of_the_package.ts
+++ b/Source/JavaScript/for_JsonSerializer/when_metadata_is_written_by_another_copy_of_the_package.ts
@@ -2,17 +2,17 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { DerivedType } from '../DerivedType';
+import { Field } from '../Field';
 import { Fields } from '../Fields';
+import { addFieldToDecoratorMetadata, getOwnDecoratorFieldsForType } from '../fieldDecoratorMetadata';
 
 /**
  * Pins why `Fields` and `DerivedType` were left keyed on the constructor while the converter registry
  * was not.
  *
- * Neither holds state in module scope. Both write reflect metadata keyed on the target constructor, so
- * the state lives with the type being described rather than with the class describing it, and a
- * duplicated `Fields` reads what another `Fields` wrote. (In a real duplicate install the two copies
- * also share one metadata store, because the polyfill installs only when the global `Reflect` lacks it
- * - here a single `reflection` module is loaded, which is the same store by construction.)
+ * Neither holds state in module scope. Legacy metadata is keyed on the target constructor and standard
+ * metadata is keyed on the metadata object attached to that constructor. Both live in the shared
+ * Reflect metadata store, so a duplicated reader can read what another package copy wrote.
  *
  * That is the whole reason those two kept comparing constructors while the converter registry stopped.
  * If it ever stops being true, this goes red and they need the same treatment the converters got.
@@ -22,25 +22,43 @@ describe('when metadata is written by another copy of the package', () => {
     let derivedTypeIsDistinct: boolean;
     let fieldNamesReadByTheOtherCopy: string[];
     let derivedTypeReadByTheOtherCopy: string | undefined;
+    let standardFieldNamesReadByOtherFieldsCopy: string[];
+    let standardFieldNamesReadByTheOtherCopy: string[];
+    let standardMetadataCopiesAreDistinct: boolean;
 
     beforeEach(async () => {
         const otherFields = await import(/* @vite-ignore */ '../Fields?anotherCopy') as typeof import('../Fields');
         const otherDerivedType = await import(/* @vite-ignore */ '../DerivedType?anotherCopy') as typeof import('../DerivedType');
+        const standardMetadataWriter = await import(/* @vite-ignore */ '../fieldDecoratorMetadata?writerCopy') as typeof import('../fieldDecoratorMetadata');
+        const standardMetadataReader = await import(/* @vite-ignore */ '../fieldDecoratorMetadata?readerCopy') as typeof import('../fieldDecoratorMetadata');
 
         fieldsAreDistinct = Fields !== otherFields.Fields;
         derivedTypeIsDistinct = DerivedType !== otherDerivedType.DerivedType;
+        standardMetadataCopiesAreDistinct = standardMetadataWriter.addFieldToDecoratorMetadata !== addFieldToDecoratorMetadata &&
+            standardMetadataReader.getOwnDecoratorFieldsForType !== getOwnDecoratorFieldsForType &&
+            standardMetadataWriter.addFieldToDecoratorMetadata !== standardMetadataReader.addFieldToDecoratorMetadata;
 
         class Subject { }
 
         Fields.addFieldToType(Subject, 'name', String, false, [], []);
         DerivedType.set(Subject, 'an-identifier');
 
+        class StandardSubject { }
+        const metadata: Record<PropertyKey, unknown> = Object.create(null) as Record<PropertyKey, unknown>;
+        standardMetadataWriter.addFieldToDecoratorMetadata(metadata, new Field('standardName', String, false, [], []));
+        Object.defineProperty(StandardSubject, Symbol.metadata, { value: metadata });
+
         fieldNamesReadByTheOtherCopy = otherFields.Fields.getFieldsForType(Subject).map(_ => _.name);
         derivedTypeReadByTheOtherCopy = otherDerivedType.DerivedType.get(Subject);
+        standardFieldNamesReadByTheOtherCopy = standardMetadataReader.getOwnDecoratorFieldsForType(StandardSubject).map(_ => _.name);
+        standardFieldNamesReadByOtherFieldsCopy = otherFields.Fields.getFieldsForType(StandardSubject).map(_ => _.name);
     });
 
     it('should be a genuinely different Fields', () => fieldsAreDistinct.should.be.true);
     it('should be a genuinely different DerivedType', () => derivedTypeIsDistinct.should.be.true);
+    it('should use genuinely different standard metadata helpers', () => standardMetadataCopiesAreDistinct.should.be.true);
     it('should read a field the other copy wrote', () => fieldNamesReadByTheOtherCopy.should.deep.equal(['name']));
     it('should read a derived type the other copy wrote', () => derivedTypeReadByTheOtherCopy!.should.equal('an-identifier'));
+    it('should read a standard field another metadata helper copy wrote', () => standardFieldNamesReadByTheOtherCopy.should.deep.equal(['standardName']));
+    it('should expose standard metadata through another Fields copy', () => standardFieldNamesReadByOtherFieldsCopy.should.deep.equal(['standardName']));
 });

--- a/Source/JavaScript/for_derivedTypeDecorator/when_an_outer_standard_decorator_replaces_the_class.ts
+++ b/Source/JavaScript/for_derivedTypeDecorator/when_an_outer_standard_decorator_replaces_the_class.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Constructor } from '../Constructor';
+import { DerivedType } from '../DerivedType';
+import { derivedType } from '../derivedTypeDecorator';
+
+class BaseType { }
+class OriginalType extends BaseType { }
+class ReplacementType extends OriginalType { }
+
+describe('when an outer standard decorator replaces the class', () => {
+    const initializers: Array<(this: Constructor) => void> = [];
+
+    derivedType('replacement-id')(OriginalType, {
+        addInitializer(initializer) {
+            initializers.push(initializer);
+        },
+        kind: 'class',
+        metadata: {},
+        name: 'OriginalType'
+    });
+    initializers.forEach(initializer => initializer.call(ReplacementType));
+
+    it('should not register the discarded original class', () => (DerivedType.get(OriginalType) === undefined).should.be.true);
+    it('should register the final replacement class', () => DerivedType.get(ReplacementType).should.equal('replacement-id'));
+    it('should register the replacement with its base type', () => DerivedType.getDerivedTypesFor(BaseType).should.deep.equal([ReplacementType]));
+});

--- a/Source/JavaScript/for_fieldDecorator/fixtures/standard_decorated_types.ts
+++ b/Source/JavaScript/for_fieldDecorator/fixtures/standard_decorated_types.ts
@@ -1,0 +1,76 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+declare const fundamentals: typeof import('../../index');
+
+const { derivedType, field, JsonSerializer, ValueMap } = fundamentals;
+
+function replaceClass<Target extends import('../../Constructor').Constructor>(target: Target): Target {
+    return class extends target { } as Target;
+}
+
+class Shape {
+    @field(String)
+    label!: string;
+}
+
+@derivedType('circle')
+class Circle extends Shape {
+    @field(Number)
+    radius!: number;
+}
+
+@derivedType('rectangle')
+class Rectangle extends Shape {
+    @field(Number)
+    width!: number;
+
+    @field(Number)
+    height!: number;
+}
+
+@replaceClass
+@derivedType('replacement')
+class ReplacedShape extends Shape { }
+
+class Drawing {
+    static instanceCount = 0;
+
+    @field(String)
+    title!: string;
+
+    @field(Date)
+    createdAt!: Date;
+
+    @field(Shape, true)
+    shapes!: Shape[];
+
+    @field(ValueMap, { genericArguments: [String, Number] })
+    scores!: InstanceType<typeof ValueMap<string, number>>;
+
+    constructor() {
+        Drawing.instanceCount++;
+    }
+}
+
+const instanceCountBeforeDeserialize = Drawing.instanceCount;
+const drawing = JsonSerializer.deserialize(Drawing, JSON.stringify({
+    createdAt: '2026-08-16T09:30:00.000Z',
+    scores: {
+        first: 42
+    },
+    shapes: [{
+        _derivedTypeId: 'circle',
+        label: 'First',
+        radius: 12
+    }, {
+        _derivedTypeId: 'rectangle',
+        height: 4,
+        label: 'Second',
+        width: 8
+    }],
+    title: 'Standard decorators'
+}));
+const instanceCountAfterDeserialize = Drawing.instanceCount;
+
+void [Circle, Rectangle, ReplacedShape, instanceCountBeforeDeserialize, drawing, instanceCountAfterDeserialize];

--- a/Source/JavaScript/for_fieldDecorator/when_executing_standard_typescript_decorator_emit.ts
+++ b/Source/JavaScript/for_fieldDecorator/when_executing_standard_typescript_decorator_emit.ts
@@ -1,0 +1,109 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { Script } from 'node:vm';
+import { createProgram, getPreEmitDiagnostics, ModuleKind, ModuleResolutionKind, ScriptTarget, transpileModule } from 'typescript';
+import * as fundamentals from '../index';
+
+describe('when executing standard TypeScript decorator emit', () => {
+    const originalMetadataDescriptor = Object.getOwnPropertyDescriptor(Symbol, 'metadata');
+    let emittedJavaScript: string;
+    let symbolMetadataWasAbsent: boolean;
+    let symbolMetadataWasPolyfilled: boolean;
+    let executionResult: {
+        Circle: fundamentals.Constructor;
+        Drawing: fundamentals.Constructor;
+        Rectangle: fundamentals.Constructor;
+        ReplacedShape: fundamentals.Constructor;
+        Shape: fundamentals.Constructor;
+        drawing: {
+            createdAt: Date;
+            scores: fundamentals.ValueMap<string, number>;
+            shapes: object[];
+            title: string;
+        };
+        instanceCountAfterDeserialize: number;
+        instanceCountBeforeDeserialize: number;
+    };
+    let registeredDerivedTypes: fundamentals.Constructor[];
+    let legacySemanticDiagnosticCount: number;
+    let semanticDiagnosticCount: number;
+
+    beforeAll(async () => {
+        Reflect.deleteProperty(Symbol, 'metadata');
+        symbolMetadataWasAbsent = !Object.prototype.hasOwnProperty.call(Symbol, 'metadata');
+
+        await import(/* @vite-ignore */ '../reflection?standardTypeScriptEmit');
+        symbolMetadataWasPolyfilled = Symbol.metadata === Symbol.for('Symbol.metadata');
+
+        const fixtureUrl = new URL('./fixtures/standard_decorated_types.ts', import.meta.url);
+        const fixturePath = fileURLToPath(fixtureUrl);
+        const source = readFileSync(fixtureUrl, 'utf8');
+        const compilerOptions = {
+            lib: ['lib.esnext.d.ts', 'lib.dom.d.ts'],
+            module: ModuleKind.ES2022,
+            moduleResolution: ModuleResolutionKind.Bundler,
+            noEmit: true,
+            noImplicitAny: false,
+            skipLibCheck: true,
+            strict: true,
+            target: ScriptTarget.ES2022
+        };
+        const standardProgram = createProgram({
+            options: {
+                ...compilerOptions,
+                emitDecoratorMetadata: false,
+                experimentalDecorators: false,
+            },
+            rootNames: [fixturePath]
+        });
+        const legacyProgram = createProgram({
+            options: {
+                ...compilerOptions,
+                emitDecoratorMetadata: true,
+                experimentalDecorators: true,
+            },
+            rootNames: [fixturePath]
+        });
+        semanticDiagnosticCount = getPreEmitDiagnostics(standardProgram).length;
+        legacySemanticDiagnosticCount = getPreEmitDiagnostics(legacyProgram).length;
+        emittedJavaScript = transpileModule(source, {
+            compilerOptions: {
+                emitDecoratorMetadata: false,
+                experimentalDecorators: false,
+                module: ModuleKind.None,
+                target: ScriptTarget.ES2022
+            },
+            fileName: 'standard_decorated_types.ts',
+            reportDiagnostics: true
+        }).outputText;
+
+        const script = new Script(`${emittedJavaScript}\n({ Circle, Drawing, Rectangle, ReplacedShape, Shape, drawing, instanceCountAfterDeserialize, instanceCountBeforeDeserialize })`);
+        executionResult = script.runInNewContext({ Array, Boolean, Date, fundamentals, JSON, Number, Object, String, Symbol }) as typeof executionResult;
+        registeredDerivedTypes = fundamentals.DerivedType.getDerivedTypesFor(executionResult.Shape);
+    });
+
+    afterAll(() => {
+        Reflect.deleteProperty(Symbol, 'metadata');
+        if (originalMetadataDescriptor) Object.defineProperty(Symbol, 'metadata', originalMetadataDescriptor);
+    });
+
+    it('should begin without runtime Symbol metadata support', () => symbolMetadataWasAbsent.should.be.true);
+    it('should install the Symbol metadata polyfill before class evaluation', () => symbolMetadataWasPolyfilled.should.be.true);
+    it('should type check the standard decorator signatures', () => semanticDiagnosticCount.should.equal(0));
+    it('should type check the legacy decorator signatures', () => legacySemanticDiagnosticCount.should.equal(0));
+    it('should execute standard decorator helper emit', () => emittedJavaScript.should.contain('__esDecorate'));
+    it('should expose field metadata before constructing an instance', () => executionResult.instanceCountBeforeDeserialize.should.equal(0));
+    it('should construct the target only during first-call deserialization', () => executionResult.instanceCountAfterDeserialize.should.equal(1));
+    it('should deserialize primitive fields', () => executionResult.drawing.title.should.equal('Standard decorators'));
+    it('should deserialize date fields', () => executionResult.drawing.createdAt.should.be.instanceOf(Date));
+    it('should deserialize polymorphic array entries', () => (executionResult.drawing.shapes[0] instanceof executionResult.Circle).should.be.true);
+    it('should deserialize every registered derivative', () => (executionResult.drawing.shapes[1] instanceof executionResult.Rectangle).should.be.true);
+    it('should auto-register standard derived type decorators', () => registeredDerivedTypes.should.deep.equal([executionResult.Circle, executionResult.Rectangle, executionResult.ReplacedShape]));
+    it('should register the final class returned by an outer standard decorator', () => fundamentals.DerivedType.get(executionResult.ReplacedShape).should.equal('replacement'));
+    it('should deserialize inherited fields', () => (executionResult.drawing.shapes[0] as { label: string }).label.should.equal('First'));
+    it('should deserialize derived fields', () => (executionResult.drawing.shapes[0] as { radius: number }).radius.should.equal(12));
+    it('should deserialize generic arguments', () => executionResult.drawing.scores.get('first')!.should.equal(42));
+});

--- a/Source/JavaScript/for_fieldDecorator/when_invoked_as_a_legacy_decorator.ts
+++ b/Source/JavaScript/for_fieldDecorator/when_invoked_as_a_legacy_decorator.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Fields } from '../Fields';
+import { field } from '../fieldDecorator';
+
+class FirstDerivative { }
+class SecondDerivative { }
+class LegacyDecoratedType { }
+
+describe('when invoked as a legacy decorator', () => {
+    field(Number)(LegacyDecoratedType.prototype, 'count');
+    field(String, true, [FirstDerivative, SecondDerivative], [String, Number])(LegacyDecoratedType.prototype, 'values');
+
+    const fields = Fields.getFieldsForType(LegacyDecoratedType);
+
+    it('should register a primitive field', () => fields.find(_ => _.name === 'count')!.type.should.equal(Number));
+    it('should preserve enumerable semantics', () => fields.find(_ => _.name === 'values')!.enumerable.should.be.true);
+    it('should preserve derivative semantics', () => fields.find(_ => _.name === 'values')!.derivatives.should.deep.equal([FirstDerivative, SecondDerivative]));
+    it('should preserve generic argument semantics', () => fields.find(_ => _.name === 'values')!.genericArguments.should.deep.equal([String, Number]));
+});

--- a/Source/JavaScript/for_fieldDecorator/when_invoked_as_a_standard_decorator.ts
+++ b/Source/JavaScript/for_fieldDecorator/when_invoked_as_a_standard_decorator.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Fields } from '../Fields';
+import { field } from '../fieldDecorator';
+import { StandardFieldDecoratorContext } from '../StandardFieldDecoratorContext';
+
+class FirstDerivative { }
+class SecondDerivative { }
+
+class StandardDecoratedType {
+    static instanceCount = 0;
+
+    constructor() {
+        StandardDecoratedType.instanceCount++;
+    }
+}
+
+describe('when invoked as a standard decorator', () => {
+    const metadata: Record<PropertyKey, unknown> = Object.create(null) as Record<PropertyKey, unknown>;
+    const contextFor = (name: string): StandardFieldDecoratorContext => ({
+        kind: 'field',
+        metadata,
+        name,
+        private: false,
+        static: false
+    });
+
+    field(Number)(undefined, contextFor('count'));
+    field(Date)(undefined, contextFor('createdAt'));
+    field(String, true)(undefined, contextFor('names'));
+    field(Object, { derivatives: [FirstDerivative, SecondDerivative], genericArguments: [String, Number] })(undefined, contextFor('value'));
+    Object.defineProperty(StandardDecoratedType, Symbol.metadata, { value: metadata });
+
+    const fields = Fields.getFieldsForType(StandardDecoratedType);
+
+    it('should expose metadata before constructing an instance', () => StandardDecoratedType.instanceCount.should.equal(0));
+    it('should register a primitive field', () => fields.find(_ => _.name === 'count')!.type.should.equal(Number));
+    it('should register a date field', () => fields.find(_ => _.name === 'createdAt')!.type.should.equal(Date));
+    it('should register an array field', () => fields.find(_ => _.name === 'names')!.enumerable.should.be.true);
+    it('should register derivatives', () => fields.find(_ => _.name === 'value')!.derivatives.should.deep.equal([FirstDerivative, SecondDerivative]));
+    it('should register generic arguments', () => fields.find(_ => _.name === 'value')!.genericArguments.should.deep.equal([String, Number]));
+});

--- a/Source/JavaScript/for_fieldDecorator/when_invoked_for_an_unsupported_legacy_field/with_a_static_field.ts
+++ b/Source/JavaScript/for_fieldDecorator/when_invoked_for_an_unsupported_legacy_field/with_a_static_field.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { field } from '../../fieldDecorator';
+
+class Subject { }
+
+describe('when invoked for an unsupported legacy field with a static field', () => {
+    const invoke = () => field(String)(Subject, 'value');
+
+    it('should reject the field', () => invoke.should.throw(TypeError, '@field cannot decorate static fields'));
+});

--- a/Source/JavaScript/for_fieldDecorator/when_invoked_for_an_unsupported_legacy_field/with_a_symbol_name.ts
+++ b/Source/JavaScript/for_fieldDecorator/when_invoked_for_an_unsupported_legacy_field/with_a_symbol_name.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { field } from '../../fieldDecorator';
+
+class Subject { }
+
+describe('when invoked for an unsupported legacy field with a symbol name', () => {
+    const invoke = () => field(String)(Subject.prototype, Symbol('value'));
+
+    it('should reject the field', () => invoke.should.throw(TypeError, '@field cannot decorate symbol-named fields'));
+});

--- a/Source/JavaScript/for_fieldDecorator/when_invoked_for_an_unsupported_standard_field/with_a_private_field.ts
+++ b/Source/JavaScript/for_fieldDecorator/when_invoked_for_an_unsupported_standard_field/with_a_private_field.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { field } from '../../fieldDecorator';
+
+describe('when invoked for an unsupported standard field with a private field', () => {
+    const invoke = () => field(String)(undefined, {
+        kind: 'field',
+        metadata: {},
+        name: '#value',
+        private: true,
+        static: false
+    });
+
+    it('should reject the field', () => invoke.should.throw(TypeError, '@field cannot decorate private fields'));
+});

--- a/Source/JavaScript/for_fieldDecorator/when_invoked_for_an_unsupported_standard_field/with_a_static_field.ts
+++ b/Source/JavaScript/for_fieldDecorator/when_invoked_for_an_unsupported_standard_field/with_a_static_field.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { field } from '../../fieldDecorator';
+
+describe('when invoked for an unsupported standard field with a static field', () => {
+    const invoke = () => field(String)(undefined, {
+        kind: 'field',
+        metadata: {},
+        name: 'value',
+        private: false,
+        static: true
+    });
+
+    it('should reject the field', () => invoke.should.throw(TypeError, '@field cannot decorate static fields'));
+});

--- a/Source/JavaScript/for_fieldDecorator/when_invoked_for_an_unsupported_standard_field/with_a_symbol_name.ts
+++ b/Source/JavaScript/for_fieldDecorator/when_invoked_for_an_unsupported_standard_field/with_a_symbol_name.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { field } from '../../fieldDecorator';
+
+describe('when invoked for an unsupported standard field with a symbol name', () => {
+    const invoke = () => field(String)(undefined, {
+        kind: 'field',
+        metadata: {},
+        name: Symbol('value'),
+        private: false,
+        static: false
+    });
+
+    it('should reject the field', () => invoke.should.throw(TypeError, '@field cannot decorate symbol-named fields'));
+});

--- a/Source/JavaScript/for_fieldDecorator/when_invoked_for_an_unsupported_standard_field/without_decorator_metadata.ts
+++ b/Source/JavaScript/for_fieldDecorator/when_invoked_for_an_unsupported_standard_field/without_decorator_metadata.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { field } from '../../fieldDecorator';
+
+describe('when invoked for an unsupported standard field without decorator metadata', () => {
+    const invoke = () => field(String)(undefined, {
+        kind: 'field',
+        metadata: undefined,
+        name: 'value',
+        private: false,
+        static: false
+    });
+
+    it('should reject the field', () => invoke.should.throw(TypeError, '@field requires standard decorator metadata support'));
+});

--- a/Source/JavaScript/for_fieldDecorator/when_legacy_and_standard_metadata_are_mixed_across_inheritance.ts
+++ b/Source/JavaScript/for_fieldDecorator/when_legacy_and_standard_metadata_are_mixed_across_inheritance.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Fields } from '../Fields';
+import { field } from '../fieldDecorator';
+import { StandardFieldDecoratorContext } from '../StandardFieldDecoratorContext';
+
+class LegacyBase { }
+class StandardDerived extends LegacyBase { }
+class StandardBase { }
+class LegacyDerived extends StandardBase { }
+
+describe('when legacy and standard metadata are mixed across inheritance', () => {
+    const standardDerivedMetadata: Record<PropertyKey, unknown> = Object.create(null) as Record<PropertyKey, unknown>;
+    const standardBaseMetadata: Record<PropertyKey, unknown> = Object.create(null) as Record<PropertyKey, unknown>;
+    const contextFor = (name: string, metadata: Record<PropertyKey, unknown>): StandardFieldDecoratorContext => ({
+        kind: 'field',
+        metadata,
+        name,
+        private: false,
+        static: false
+    });
+
+    field(String)(LegacyBase.prototype, 'value');
+    field(String)(LegacyBase.prototype, 'legacyBaseValue');
+    field(Number)(undefined, contextFor('value', standardDerivedMetadata));
+    field(Number)(undefined, contextFor('standardDerivedValue', standardDerivedMetadata));
+    Object.defineProperty(StandardDerived, Symbol.metadata, { value: standardDerivedMetadata });
+
+    field(String)(undefined, contextFor('value', standardBaseMetadata));
+    field(String)(undefined, contextFor('standardBaseValue', standardBaseMetadata));
+    Object.defineProperty(StandardBase, Symbol.metadata, { value: standardBaseMetadata });
+    field(Boolean)(LegacyDerived.prototype, 'value');
+    field(Boolean)(LegacyDerived.prototype, 'legacyDerivedValue');
+
+    const standardDerivedFields = Fields.getFieldsForType(StandardDerived);
+    const legacyDerivedFields = Fields.getFieldsForType(LegacyDerived);
+
+    it('should inherit legacy fields into a standard derived type', () => standardDerivedFields.find(_ => _.name === 'legacyBaseValue')!.type.should.equal(String));
+    it('should let a standard field override a legacy base field', () => standardDerivedFields.find(_ => _.name === 'value')!.type.should.equal(Number));
+    it('should inherit standard fields into a legacy derived type', () => legacyDerivedFields.find(_ => _.name === 'standardBaseValue')!.type.should.equal(String));
+    it('should let a legacy field override a standard base field', () => legacyDerivedFields.find(_ => _.name === 'value')!.type.should.equal(Boolean));
+});

--- a/Source/JavaScript/for_fieldDecorator/when_standard_metadata_contains_unrelated_fields_metadata.ts
+++ b/Source/JavaScript/for_fieldDecorator/when_standard_metadata_contains_unrelated_fields_metadata.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Field } from '../Field';
+import { Fields } from '../Fields';
+import { field } from '../fieldDecorator';
+
+describe('when standard metadata contains unrelated fields metadata', () => {
+    let fields: Field[];
+    let metadata: Record<PropertyKey, unknown>;
+    let unrelatedMetadata: object;
+
+    beforeEach(() => {
+        class Subject { }
+
+        metadata = Object.create(null) as Record<PropertyKey, unknown>;
+        unrelatedMetadata = { source: 'another library' };
+        Reflect.defineMetadata('fields', unrelatedMetadata, metadata);
+
+        field(String)(undefined, {
+            kind: 'field',
+            metadata,
+            name: 'name',
+            private: false,
+            static: false
+        });
+        Object.defineProperty(Subject, Symbol.metadata, { value: metadata });
+        fields = Fields.getFieldsForType(Subject);
+    });
+
+    it('should preserve the unrelated fields metadata', () => Reflect.getOwnMetadata('fields', metadata).should.equal(unrelatedMetadata));
+    it('should register the decorated field independently', () => fields.map(_ => _.name).should.deep.equal(['name']));
+    it('should retain the decorated field type', () => fields[0].type.should.equal(String));
+});

--- a/Source/JavaScript/for_fieldDecorator/when_standard_metadata_is_inherited_and_overridden.ts
+++ b/Source/JavaScript/for_fieldDecorator/when_standard_metadata_is_inherited_and_overridden.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Fields } from '../Fields';
+import { field } from '../fieldDecorator';
+import { StandardFieldDecoratorContext } from '../StandardFieldDecoratorContext';
+
+class BaseType { }
+class DerivedType extends BaseType { }
+
+describe('when standard metadata is inherited and overridden', () => {
+    const baseMetadata: Record<PropertyKey, unknown> = Object.create(null) as Record<PropertyKey, unknown>;
+    const derivedMetadata: Record<PropertyKey, unknown> = Object.create(baseMetadata) as Record<PropertyKey, unknown>;
+    const contextFor = (name: string, metadata: Record<PropertyKey, unknown>): StandardFieldDecoratorContext => ({
+        kind: 'field',
+        metadata,
+        name,
+        private: false,
+        static: false
+    });
+
+    field(String)(undefined, contextFor('baseValue', baseMetadata));
+    field(String)(undefined, contextFor('value', baseMetadata));
+    field(Number)(undefined, contextFor('value', derivedMetadata));
+    field(Boolean)(undefined, contextFor('derivedValue', derivedMetadata));
+    Object.defineProperty(BaseType, Symbol.metadata, { value: baseMetadata });
+    Object.defineProperty(DerivedType, Symbol.metadata, { value: derivedMetadata });
+
+    const baseFields = Fields.getFieldsForType(BaseType);
+    const derivedFields = Fields.getFieldsForType(DerivedType);
+
+    it('should preserve fields declared by the base type', () => derivedFields.find(_ => _.name === 'baseValue')!.type.should.equal(String));
+    it('should preserve fields declared by the derived type', () => derivedFields.find(_ => _.name === 'derivedValue')!.type.should.equal(Boolean));
+    it('should keep a single overridden field', () => derivedFields.filter(_ => _.name === 'value').should.have.lengthOf(1));
+    it('should use the derived field definition', () => derivedFields.find(_ => _.name === 'value')!.type.should.equal(Number));
+    it('should not mutate the base field definition', () => baseFields.find(_ => _.name === 'value')!.type.should.equal(String));
+});

--- a/Source/JavaScript/for_reflection/when_loading_with_existing_symbol_metadata.ts
+++ b/Source/JavaScript/for_reflection/when_loading_with_existing_symbol_metadata.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+describe('when loading with existing Symbol metadata', () => {
+    const originalMetadataDescriptor = Object.getOwnPropertyDescriptor(Symbol, 'metadata');
+    const existingMetadata = Symbol('existing metadata');
+    let actualMetadata: symbol;
+
+    beforeAll(async () => {
+        Object.defineProperty(Symbol, 'metadata', {
+            configurable: true,
+            value: existingMetadata
+        });
+
+        await import(/* @vite-ignore */ '../reflection?existingSymbolMetadata');
+        actualMetadata = Symbol.metadata;
+    });
+
+    afterAll(() => {
+        Reflect.deleteProperty(Symbol, 'metadata');
+        if (originalMetadataDescriptor) Object.defineProperty(Symbol, 'metadata', originalMetadataDescriptor);
+    });
+
+    it('should preserve the existing identity', () => actualMetadata.should.equal(existingMetadata));
+});

--- a/Source/JavaScript/reflection.ts
+++ b/Source/JavaScript/reflection.ts
@@ -29,6 +29,19 @@ declare global {
     }
 }
 
+// Standard decorators expose their class metadata through Symbol.metadata. Define it before any
+// decorated class is evaluated on runtimes that do not provide it yet. Symbol.for keeps the value
+// stable if more than one copy of this package is loaded in the same realm.
+const symbolConstructor = Symbol as unknown as { metadata?: unknown };
+if (symbolConstructor.metadata === undefined || symbolConstructor.metadata === null) {
+    Object.defineProperty(Symbol, 'metadata', {
+        configurable: true,
+        enumerable: false,
+        value: Symbol.for('Symbol.metadata'),
+        writable: false
+    });
+}
+
 // Check if native metadata API is available by testing for multiple methods
 if (typeof Reflect.defineMetadata !== 'function' || typeof Reflect.getOwnMetadata !== 'function') {
     const metadataMap = new WeakMap<any, Map<string | symbol, any>>();


### PR DESCRIPTION
# Summary

Make Fundamentals decorators work with both legacy and standard decorator emit while restoring clean .NET package builds after automated dependency updates.

## Added

- Added standard TypeScript decorator support for field and derived-type metadata while retaining legacy decorator compatibility. (Cratis/Arc#2440)

## Fixed

- Fixed NuGet restore failures caused by duplicate case-insensitive Handlebars package pins.