### PR TITLE
Forbid squash merges

### DIFF
--- a/.ai/rules/general.md
+++ b/.ai/rules/general.md
@@ -41,6 +41,7 @@ When these instructions don't explicitly cover a situation, apply these values t
 - Always reuse the active terminal for commands.
 - Do not create new terminals unless current one is busy or fails.
 - When asked to commit, push, create a PR, ship, or land changes, always use the **ship-changes** skill.
+- **Never squash-merge a pull request.** Default to a normal merge commit that preserves every PR commit. A rebase merge is permitted only when explicitly requested by the user or required by documented repository policy; never choose it as an unrequested fallback.
 
 ## Development Workflow
 

--- a/.ai/rules/pull-requests.md
+++ b/.ai/rules/pull-requests.md
@@ -32,6 +32,14 @@ Quick reminders:
   - **minor** — new features, new slices, non-breaking additions
   - **patch** — bug fixes, docs, refactoring with identical behavior
 
+## Merge Method
+
+- **Never squash-merge a pull request.** Squash merging destroys the PR's commit history and is prohibited without exception.
+- Default to a normal merge commit: GitHub's **Create a merge commit** option, `merge_method: merge` in the GitHub API/MCP tool, or `gh pr merge --merge` in the CLI.
+- Immediately before merging, verify the selected method. Never use `--squash` or `merge_method: squash`.
+- A rebase merge may be used only when the user explicitly requests it or documented repository policy requires it. Never choose rebase merely because normal merge commits are unavailable or to clean up commit history.
+- If the allowed merge method cannot be verified, stop and do not merge. Fix poor commits on the branch before merging; never destroy PR history at merge time.
+
 ## Quality Gates
 
 Before marking a PR ready for review:

--- a/.ai/skills/ship-changes/SKILL.md
+++ b/.ai/skills/ship-changes/SKILL.md
@@ -115,8 +115,8 @@ git push -u origin <branch-name>
 
 Use `mcp_github_github_create_pull_request` with:
 
-- `owner`: `Cratis`
-- `repo`: `Chronicle`
+- `owner`: derive from the current repository's `origin` remote
+- `repo`: derive from the current repository's `origin` remote
 - `head`: the branch name
 - `base`: `main`
 - `title`: short imperative sentence describing the overall change
@@ -147,7 +147,7 @@ Rules:
 ### Searching for a related issue
 
 ```
-mcp_github_github_search_issues  query="<keywords> repo:Cratis/Chronicle"
+mcp_github_github_search_issues  query="<keywords> repo:<owner>/<repo>"
 ```
 
 If nothing relevant is found, omit the issue reference from affected bullets.
@@ -166,12 +166,25 @@ Otherwise use `gh pr edit <number> --add-label "<label>"` with one of:
 
 ## Step 7 — Merge the PR
 
+**Never squash-merge. Preserve every commit and its history.**
+
+Immediately before merging:
+
+1. Verify that the PR is mergeable and all required checks pass.
+2. Verify that the selected merge method is not squash.
+3. Default to `merge` / **Create a merge commit** unless the user explicitly requests rebase or documented repository policy requires it.
+4. If the allowed merge method is unavailable or cannot be verified, stop and do not merge. Never fall back to squash.
+
 Use `mcp_github_github_merge_pull_request` with:
 
-- `merge_method`: `merge`
-- `owner`: `Cratis`
-- `repo`: `Chronicle`
+- `merge_method`: `merge` by default; `rebase` only with explicit user direction or documented repository policy; never `squash`
+- `owner`: derive from the current repository's `origin` remote
+- `repo`: derive from the current repository's `origin` remote
 - `pullNumber`: the PR number returned in step 5
+
+For the GitHub CLI, use `gh pr merge <number> --merge` by default. `--rebase` is permitted only with explicit user direction or documented repository policy. Never pass `--squash`.
+
+After merging, verify that every PR commit remains represented in the resulting history. If it does not, report the problem immediately; do not rewrite published history without explicit authorization.
 
 ## Step 8 — Clean up the branch
 
@@ -230,4 +243,5 @@ git checkout main && git pull && git branch -d fix/testing-package-orleans-runti
 - **Never leave placeholder text** in PR bodies (`(#issue)`, `(#123)`).
 - **Never commit code that does not compile** — every commit must be a working state.
 - **Never push directly to `main`** — always go through the branch + PR flow.
+- **Never squash-merge** — use a normal merge commit by default; rebase only when explicitly requested or required by documented repository policy.
 - **Never skip branch cleanup** — delete both the local and remote branch after merging.


### PR DESCRIPTION
## Changed
- Prohibit squash-merging pull requests so every commit and its history are preserved.

## Notes
- Normal merge commits are the default.
- Rebase merges remain permitted only when explicitly requested or required by documented repository policy.
- Agents must verify the selected merge method immediately before merging and stop rather than fall back to squash.
- The shipping skill now derives the repository from the current `origin` instead of hard-coding another repository.
