### PR TITLE
Adopt the organization reusable workflows

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,5 +1,7 @@
 name: Trigger documentation build
 
+# Thin caller of the organization-wide documentation dispatcher in
+# Cratis/Workflows/.github/workflows/trigger-documentation-build.yml.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -17,12 +19,6 @@ permissions:
 
 jobs:
   trigger:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - name: Trigger Documentation Build
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.PAT_DOCUMENTATION }}
-          repository: Cratis/Documentation
-          event-type: build-docs
+    uses: Cratis/Workflows/.github/workflows/trigger-documentation-build.yml@main
+    secrets:
+      PAT_DOCUMENTATION: ${{ secrets.PAT_DOCUMENTATION }}

--- a/.github/workflows/verify-semver-label.yml
+++ b/.github/workflows/verify-semver-label.yml
@@ -1,12 +1,10 @@
 name: Verify Semver Label
 
-# A merged pull request with no major/minor/patch label produces a Publish run that reports success while
-# skipping every publish step, because the release action resolves should-publish to false. That reads as a
-# release having happened when nothing was published. Requiring the label here turns a silent non-release into
-# a visible failure before the merge, where it costs nothing to fix.
-#
-# Triggered on labeled/unlabeled as well as the usual events, so adding the label re-runs the check rather than
-# leaving a red cross behind that only a push would clear.
+# Thin caller of the organization-wide release-intent gate. The policy - which
+# labels are accepted and what the errors say - lives in
+# Cratis/Workflows/.github/workflows/verify-release-intent.yml. Thirty diverging
+# per-repository copies of that logic are how the 2026-08-25 unintended releases
+# happened; do not reintroduce logic here.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -25,25 +23,4 @@ permissions:
 
 jobs:
   verify:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-
-    steps:
-      - name: Require exactly one semantic version label
-        env:
-          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
-        run: |
-          count=$(printf '%s' "$LABELS" | jq '[.[] | select(. == "major" or . == "minor" or . == "patch" or . == "no-release")] | length')
-
-          if [ "$count" -eq 1 ]; then
-            echo "Found one semantic version label."
-            exit 0
-          fi
-
-          if [ "$count" -eq 0 ]; then
-            echo "::error::This pull request has no release intent label. Add exactly one of major, minor, patch, or no-release. Without one, merging produces a Publish run that succeeds while skipping every publish step, so no release is cut and nothing is published."
-          else
-            echo "::error::This pull request carries $count release intent labels. Exactly one of major, minor, patch, or no-release is required, since the release intent cannot be derived from more than one."
-          fi
-
-          exit 1
+    uses: Cratis/Workflows/.github/workflows/verify-release-intent.yml@main


### PR DESCRIPTION
Converts copied workflow logic to thin callers of the reusables added in Cratis/Workflows#78, and removes empirically dead weight:

- .github/workflows/verify-semver-label.yml
- .github/workflows/documentation.yml

Gate semantics are identical (the reusable is Chronicle's current gate verbatim); check name becomes `verify / verify` — the ruleset audit found no branch policy pinning the old name. Doc-trigger semantics identical. cleanup-pr-artifacts is only removed where the repository has zero artifacts ever.